### PR TITLE
fix: resolve lodash CVE-2026-4800

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4496,9 +4496,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "license": "MIT"
     },
     "node_modules/lodash.defaults": {

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "brace-expansion": "^5.0.5",
     "glob": "^10.5.0",
     "minimatch": "^9.0.7",
+    "lodash": "^4.18.0",
     "rollup": "^4.59.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
- Add `lodash` override (`^4.18.0`) to resolve CVE-2026-4800 (affects `>= 4.0.0, <= 4.17.23`)
- lodash upgraded from 4.17.23 → 4.18.1 (via `archiver` → `archiver-utils`)
- `npm audit` reports 0 vulnerabilities

## Test plan
- [x] `npm audit` passes
- [x] `npm ls lodash` confirms 4.18.1
- [x] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix lodash CVE-2026-4800 by pinning dependency to ^4.18.0
> Adds `lodash` at `^4.18.0` as an explicit production dependency in [package.json](https://github.com/InsForge/insforge-mcp/pull/53/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519) to resolve a known CVE in previously resolved transitive versions.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1978d07.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency version management to ensure consistent resolution of transitive dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->