### PR TITLE
feat(tracking): tag agent-connected requests with client=mcp

### DIFF
--- a/src/shared/usage-tracker.test.ts
+++ b/src/shared/usage-tracker.test.ts
@@ -83,6 +83,7 @@ describe('UsageTracker', () => {
       const body = JSON.parse(agentCall![1].body);
       expect(body.app_key).toBe('uhzx8md3');
       expect(body.project_id).toBeUndefined();
+      expect(body.client).toBe('mcp');
 
       // No Authorization header in local mode
       expect(agentCall![1].headers['Authorization']).toBeUndefined();

--- a/src/shared/usage-tracker.ts
+++ b/src/shared/usage-tracker.ts
@@ -73,7 +73,7 @@ export class UsageTracker {
 
   private async reportAgentConnected(): Promise<void> {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const body: Record<string, any> = {};
+    const body: Record<string, any> = { client: 'mcp' };
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const headers: Record<string, any> = { 'Content-Type': 'application/json' };
 


### PR DESCRIPTION
## Summary

- `UsageTracker.reportAgentConnected()` now sends `client: 'mcp'` in the request body to `/tracking/v1/agent-connected`.
- Adds an assertion in `usage-tracker.test.ts` to lock in the new behavior.

## Why

Pairs with [insforge-cloud-backend#472](https://github.com/InsForge/insforge-cloud-backend/pull/472), which adds an optional `client` field on the cloud endpoint so PostHog/Mixpanel can break down agent-connected events by source. Without this MCP-side change, every MCP session reports as `client: 'unknown'` and is indistinguishable from CLI traffic.

## Test plan

- [ ] Connect any MCP client (Claude Code, Cursor, etc.) to a project, watch the `/tracking/v1/agent-connected` request body — should include `"client":"mcp"`
- [ ] Verify cloud-side event in PostHog shows `client=mcp` property
- [ ] `npm test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)