### PR TITLE
chore(release): 1.2.11

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@insforge/mcp",
-  "version": "1.2.10",
+  "version": "1.2.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@insforge/mcp",
-      "version": "1.2.10",
+      "version": "1.2.11",
       "license": "Apache-2.0",
       "dependencies": {
         "@insforge/shared-schemas": "1.1.49",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@insforge/mcp",
-  "version": "1.2.10",
+  "version": "1.2.11",
   "description": "MCP (Model Context Protocol) server for Insforge backend-as-a-service",
   "mcpName": "io.github.InsForge/insforge-mcp",
   "type": "module",

--- a/server.json
+++ b/server.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/InsForge/insforge-mcp",
     "source": "github"
   },
-  "version": "1.2.6",
+  "version": "1.2.11",
   "remotes": [
     {
       "type": "streamable-http",
@@ -18,7 +18,7 @@
     {
       "registryType": "npm",
       "identifier": "@insforge/mcp",
-      "version": "1.2.6",
+      "version": "1.2.11",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
## Summary

Version bump only — cuts a release for the `client=mcp` tracking change merged in #56 so PostHog/Mixpanel can break down agent-connected events by source once users upgrade.

## Files changed

- `package.json` 1.2.10 → 1.2.11
- `package-lock.json` 1.2.10 → 1.2.11
- `server.json` 1.2.6 → 1.2.11 (was stale, MCP Registry publish step needs this updated)

## Test plan

- [ ] CI passes
- [ ] After merge, manually trigger `publish-mcp.yml` workflow
- [ ] Verify `npm view @insforge/mcp version` returns `1.2.11`
- [ ] After a few days of upgrades, verify PostHog `agent_connected` events show non-zero `client=mcp` count

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package version to 1.2.11 across manifest files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->