### PR TITLE
feat(tools): add MCP tool annotations (INS-306)

### DIFF
--- a/src/shared/tools/database.ts
+++ b/src/shared/tools/database.ts
@@ -91,6 +91,13 @@ export function registerDatabaseTools(ctx: RegisterContext): void {
       apiKey: z.string().optional().describe('API key for authentication (optional if provided via --api_key)'),
       tableName: z.string().describe('Name of the table'),
     },
+    {
+      title: 'Get Table Schema',
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: true,
+    },
     withUsageTracking('get-table-schema', async ({ apiKey, tableName }) => {
       try {
         const actualApiKey = getApiKey(apiKey);
@@ -118,6 +125,13 @@ export function registerDatabaseTools(ctx: RegisterContext): void {
     'Index all backend metadata',
     {
       apiKey: z.string().optional().describe('API key for authentication (optional if provided via --api_key)'),
+    },
+    {
+      title: 'Get Backend Metadata',
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: true,
     },
     withUsageTracking('get-backend-metadata', async ({ apiKey }) => {
       try {
@@ -147,6 +161,13 @@ export function registerDatabaseTools(ctx: RegisterContext): void {
     {
       apiKey: z.string().optional().describe('API key for authentication (optional if provided via --api_key)'),
       ...rawSQLRequestSchema.shape,
+    },
+    {
+      title: 'Run Raw SQL',
+      readOnlyHint: false,
+      destructiveHint: true,
+      idempotentHint: false,
+      openWorldHint: true,
     },
     withUsageTracking('run-raw-sql', async ({ apiKey, query, params }) => {
       try {
@@ -184,6 +205,13 @@ export function registerDatabaseTools(ctx: RegisterContext): void {
       {
         frame: z.enum(['react', 'nextjs']).describe('Framework to use for the template (support React and Next.js)'),
         projectName: z.string().optional().describe('Name for the project directory (optional, defaults to "insforge-{frame}")'),
+      },
+      {
+        title: 'Download Starter Template',
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: true,
       },
       withUsageTracking('download-template', async ({ frame, projectName }) => {
         try {
@@ -237,6 +265,13 @@ After the command completes, \`cd ${shellEsc(targetDir)}\` and start developing.
       {
         frame: z.enum(['react', 'nextjs']).describe('Framework to use for the template (support React and Next.js)'),
         projectName: z.string().optional().describe('Name for the project directory (optional, defaults to "insforge-{frame}")'),
+      },
+      {
+        title: 'Download Starter Template',
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: true,
       },
       withUsageTracking('download-template', async ({ frame, projectName }) => {
         try {
@@ -313,6 +348,13 @@ To: Your current project directory
       apiKey: z.string().optional().describe('API key for authentication (optional if provided via --api_key)'),
       ...bulkUpsertRequestSchema.shape,
       filePath: z.string().describe('Path to CSV or JSON file containing data to import'),
+    },
+    {
+      title: 'Bulk Upsert Data',
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: true,
     },
     withUsageTracking('bulk-upsert', async ({ apiKey, table, filePath, upsertKey }) => {
       try {

--- a/src/shared/tools/deployment.ts
+++ b/src/shared/tools/deployment.ts
@@ -514,6 +514,13 @@ export function registerDeploymentTools(ctx: RegisterContext): void {
         .describe('Log source to retrieve'),
       limit: z.number().optional().default(20).describe('Number of logs to return (default: 20)'),
     },
+    {
+      title: 'Get Container Logs',
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: true,
+    },
     withUsageTracking('get-container-logs', async ({ apiKey, source, limit }) => {
       try {
         const actualApiKey = getApiKey(apiKey);
@@ -564,6 +571,13 @@ export function registerDeploymentTools(ctx: RegisterContext): void {
           .describe(
             'Absolute path to the source directory containing files to deploy (e.g., /Users/name/project). Do not use relative paths like "."'
           ),
+      },
+      {
+        title: 'Create Deployment',
+        readOnlyHint: false,
+        destructiveHint: false,
+        idempotentHint: false,
+        openWorldHint: true,
       },
       withUsageTracking('create-deployment', async ({ sourceDirectory }) => {
         try {
@@ -659,6 +673,13 @@ Run each step in order. If any step fails, do not proceed to the next step.`;
         deploymentId: z.string().describe('The deployment ID returned by create-deployment'),
         ...startDeploymentRequestSchema.shape,
       },
+      {
+        title: 'Start Deployment',
+        readOnlyHint: false,
+        destructiveHint: false,
+        idempotentHint: false,
+        openWorldHint: true,
+      },
       withUsageTracking(
         'start-deployment',
         async ({ deploymentId, projectSettings, envVars, meta }) => {
@@ -719,6 +740,13 @@ Run each step in order. If any step fails, do not proceed to the next step.`;
             'Absolute path to the source directory containing files to deploy (e.g., /Users/name/project or C:\\Users\\name\\project). Do not use relative paths like "."'
           ),
         ...startDeploymentRequestSchema.shape,
+      },
+      {
+        title: 'Create Deployment',
+        readOnlyHint: false,
+        destructiveHint: false,
+        idempotentHint: false,
+        openWorldHint: true,
       },
       withUsageTracking(
         'create-deployment',

--- a/src/shared/tools/docs.ts
+++ b/src/shared/tools/docs.ts
@@ -73,6 +73,13 @@ export function registerDocsTools(ctx: RegisterContext): void {
     'fetch-docs',
     'Fetch Insforge documentation. Use "instructions" for essential backend setup (MANDATORY FIRST), or select specific SDK docs for database, auth, storage, functions, or AI integration.',
     { docType: docTypeSchema },
+    {
+      title: 'Fetch Documentation',
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: true,
+    },
     withUsageTracking('fetch-docs', async ({ docType }) => {
       try {
         const content = await fetchDocumentation(docType);
@@ -104,6 +111,13 @@ export function registerDocsTools(ctx: RegisterContext): void {
 Supported features: ${sdkFeatureSchema.options.join(', ')}
 Supported languages: ${sdkLanguageSchema.options.join(', ')}`,
     { sdkFeature: sdkFeatureSchema, sdkLanguage: sdkLanguageSchema },
+    {
+      title: 'Fetch SDK Documentation',
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: true,
+    },
     withUsageTracking('fetch-sdk-docs', async ({ sdkFeature, sdkLanguage }) => {
       try {
         const content = await fetchSDKDocumentation(sdkFeature, sdkLanguage);
@@ -133,6 +147,13 @@ Supported languages: ${sdkLanguageSchema.options.join(', ')}`,
     'Generate an anonymous JWT token that never expires. Requires admin API key. Use this for client-side applications that need public access.',
     {
       apiKey: z.string().optional().describe('API key for authentication (optional if provided via --api_key)'),
+    },
+    {
+      title: 'Get Anonymous Key',
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: false,
+      openWorldHint: true,
     },
     withUsageTracking('get-anon-key', async ({ apiKey }) => {
       try {

--- a/src/shared/tools/functions.ts
+++ b/src/shared/tools/functions.ts
@@ -29,6 +29,13 @@ export function registerFunctionTools(ctx: RegisterContext): void {
           'The function code as a string. Must export: module.exports = async function(request) { return new Response(...) }'
         ),
       },
+      {
+        title: 'Create Edge Function',
+        readOnlyHint: false,
+        destructiveHint: false,
+        idempotentHint: false,
+        openWorldHint: true,
+      },
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       withUsageTracking('create-function', async (args: any) => {
         try {
@@ -71,6 +78,13 @@ export function registerFunctionTools(ctx: RegisterContext): void {
         codeFile: z.string().describe(
           'Path to JavaScript file containing the function code. Must export: module.exports = async function(request) { return new Response(...) }'
         ),
+      },
+      {
+        title: 'Create Edge Function',
+        readOnlyHint: false,
+        destructiveHint: false,
+        idempotentHint: false,
+        openWorldHint: true,
       },
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       withUsageTracking('create-function', async (args: any) => {
@@ -122,6 +136,13 @@ export function registerFunctionTools(ctx: RegisterContext): void {
       apiKey: z.string().optional().describe('API key for authentication (optional if provided via --api_key)'),
       slug: functionSchema.shape.slug.describe('The slug identifier of the function'),
     },
+    {
+      title: 'Get Edge Function',
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: true,
+    },
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     withUsageTracking('get-function', async (args: any) => {
       try {
@@ -156,6 +177,13 @@ export function registerFunctionTools(ctx: RegisterContext): void {
         code: z.string().optional().describe(
           'The new function code as a string. Must export: module.exports = async function(request) { return new Response(...) }'
         ),
+      },
+      {
+        title: 'Update Edge Function',
+        readOnlyHint: false,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: true,
       },
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       withUsageTracking('update-function', async (args: any) => {
@@ -200,6 +228,13 @@ export function registerFunctionTools(ctx: RegisterContext): void {
         codeFile: z.string().optional().describe(
           'Path to JavaScript file containing the new function code. Must export: module.exports = async function(request) { return new Response(...) }'
         ),
+      },
+      {
+        title: 'Update Edge Function',
+        readOnlyHint: false,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: true,
       },
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       withUsageTracking('update-function', async (args: any) => {
@@ -253,6 +288,13 @@ export function registerFunctionTools(ctx: RegisterContext): void {
     {
       apiKey: z.string().optional().describe('API key for authentication (optional if provided via --api_key)'),
       slug: functionSchema.shape.slug.describe('The slug identifier of the function to delete'),
+    },
+    {
+      title: 'Delete Edge Function',
+      readOnlyHint: false,
+      destructiveHint: true,
+      idempotentHint: true,
+      openWorldHint: true,
     },
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     withUsageTracking('delete-function', async (args: any) => {

--- a/src/shared/tools/integration-bridge.test.ts
+++ b/src/shared/tools/integration-bridge.test.ts
@@ -26,29 +26,22 @@ describe('MCP Integrated Testing Bridge', () => {
   const mockServer = {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     tool: (name: string, ...args: any[]) => {
-      let description = '';
+      // The handler callback is always the final argument. Preceding args are
+      // any combination of description (string), input schema (object), and
+      // annotations (object), matching the SDK's `tool(...)` overloads.
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      let schema: any = {};
+      const cb: any = args[args.length - 1];
+      const rest = args.slice(0, -1);
+
+      const description = typeof rest[0] === 'string' ? (rest[0] as string) : '';
+      const objectArgs = rest.filter((arg) => typeof arg === 'object' && arg !== null);
+      // First object arg is the input schema; a second object arg (if any) is annotations.
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      let cb: any;
+      const schema: any = objectArgs[0] ?? {};
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const annotations: any = objectArgs[1];
 
-      if (args.length === 1) {
-        cb = args[0];
-      } else if (args.length === 2) {
-        if (typeof args[0] === 'string') {
-          description = args[0];
-          cb = args[1];
-        } else {
-          schema = args[0];
-          cb = args[1];
-        }
-      } else if (args.length >= 3) {
-        description = args[0];
-        schema = args[1];
-        cb = args[2];
-      }
-
-      registeredTools.set(name, { description, schema, cb });
+      registeredTools.set(name, { description, schema, annotations, cb });
       return mockServer;
     }
   };
@@ -73,6 +66,25 @@ describe('MCP Integrated Testing Bridge', () => {
   it('should register tools correctly', () => {
     expect(registeredTools.size).toBeGreaterThan(0);
     expect(registeredTools.has('fetch-docs')).toBe(true);
+  });
+
+  it('should attach MCP annotations to registered tools', () => {
+    // Read-only tool: should advertise readOnlyHint and a human-readable title.
+    const fetchDocs = registeredTools.get('fetch-docs');
+    expect(fetchDocs?.annotations).toBeDefined();
+    expect(fetchDocs.annotations.title).toBe('Fetch Documentation');
+    expect(fetchDocs.annotations.readOnlyHint).toBe(true);
+    expect(fetchDocs.annotations.destructiveHint).toBe(false);
+
+    // Destructive tool: run-raw-sql can run arbitrary SQL (incl. DROP).
+    const runRawSql = registeredTools.get('run-raw-sql');
+    expect(runRawSql?.annotations).toBeDefined();
+    expect(runRawSql.annotations.readOnlyHint).toBe(false);
+    expect(runRawSql.annotations.destructiveHint).toBe(true);
+
+    // The handler must still be the captured callback, not the annotations object.
+    expect(typeof fetchDocs.cb).toBe('function');
+    expect(typeof runRawSql.cb).toBe('function');
   });
 
   it('should execute fetch-docs tool for instructions if credentials setup', async () => {

--- a/src/shared/tools/storage.ts
+++ b/src/shared/tools/storage.ts
@@ -18,6 +18,13 @@ export function registerStorageTools(ctx: RegisterContext): void {
       apiKey: z.string().optional().describe('API key for authentication (optional if provided via --api_key)'),
       ...createBucketRequestSchema.shape,
     },
+    {
+      title: 'Create Storage Bucket',
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: false,
+      openWorldHint: true,
+    },
     withUsageTracking('create-bucket', async ({ apiKey, bucketName, isPublic }) => {
       try {
         const actualApiKey = getApiKey(apiKey);
@@ -50,6 +57,13 @@ export function registerStorageTools(ctx: RegisterContext): void {
     {
       apiKey: z.string().optional().describe('API key for authentication (optional if provided via --api_key)'),
     },
+    {
+      title: 'List Storage Buckets',
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: true,
+    },
     withUsageTracking('list-buckets', async ({ apiKey }) => {
       try {
         const response = await fetch(`${API_BASE_URL}/api/storage/buckets`, {
@@ -78,6 +92,13 @@ export function registerStorageTools(ctx: RegisterContext): void {
       apiKey: z.string().optional().describe('API key for authentication (optional if provided via --api_key)'),
       // Reuse the same bucket name validation as create-bucket
       bucketName: createBucketRequestSchema.shape.bucketName,
+    },
+    {
+      title: 'Delete Storage Bucket',
+      readOnlyHint: false,
+      destructiveHint: true,
+      idempotentHint: true,
+      openWorldHint: true,
     },
     withUsageTracking('delete-bucket', async ({ apiKey, bucketName }) => {
       try {


### PR DESCRIPTION
## The ora gap

For INS-306 (ora Agent Readiness Score), ora flagged that **no tools on the InsForge MCP server carry annotations**. MCP clients use tool annotations as behavior hints (read-only vs. write, destructive vs. safe, idempotent, open-world). Without them, agents have no machine-readable signal about what each tool does to the backend.

This PR adds the MCP spec's 5 annotation hint fields to every registered tool:
`title`, `readOnlyHint`, `destructiveHint`, `idempotentHint`, `openWorldHint`.

## Approach chosen

The shared `registerTool(name, description, zodSchema, handler)` wrapper in `src/shared/tools/index.ts` is already variadic (`(server.tool as any)(toolName, ...args)`) and forwards its arguments straight to the SDK's `server.tool`.

The installed `@modelcontextprotocol/sdk` (1.28.0) exposes the overload:

```ts
tool(name, description, paramsSchema, annotations, cb)
```

So the **least-invasive, type-safe** change is to pass an annotations object **positionally between the input schema and the handler** at each call site. This requires:
- **zero change** to the `registerTool` wrapper, and
- **no new `any`** beyond what already exists.

I considered switching every registration to the object form `server.registerTool(name, { description, inputSchema, annotations }, handler)`, but that would rewrite all ~22 call sites for no functional gain; the positional form is the smaller, more consistent diff.

The wrapper file (`index.ts`), `src/http/server.ts`, and `src/shared/tool-catalog.ts` are intentionally untouched (the latter two belong to PR #60).

## Per-tool annotation rationale

| Category | Tools | readOnly | destructive |
|---|---|---|---|
| Read-only | get-table-schema, get-backend-metadata, get-function, list-buckets, get-anon-key, get-container-logs, fetch-docs, fetch-sdk-docs, download-template | true | false |
| Destructive | delete-bucket, delete-function, run-raw-sql (arbitrary SQL incl. DROP) | false | true |
| Non-destructive writes | create-bucket, create-function, update-function, bulk-upsert, create-deployment, start-deployment | false | false |

- `idempotentHint: true` set where natural: reads (`get-*`/`list-*`), `bulk-upsert` (upsert), and `update-function`/`delete-function`/`delete-bucket` (keyed by id/slug).
- `idempotentHint` left default (false) for `create-*`, `start-deployment`, and `get-anon-key` (each call mints a fresh non-expiring token).
- `openWorldHint: true` everywhere: all tools call the external InsForge backend.
- Each tool gets a concise human-readable `title`.

Tools registered twice (remote + local mode for `create-function`, `update-function`, `create-deployment`, `download-template`) receive identical annotations in both branches.

## Test change

The `integration-bridge.test.ts` mock server previously extracted the handler as `args[2]`, which breaks once an annotations object is inserted before the handler. Updated it to extract the handler as the **final** argument (robust to the extra arg) and to capture annotations. Added an assertion verifying annotations are attached (read-only `fetch-docs` and destructive `run-raw-sql`).

## Verification run (all in the worktree)

| Command | Result |
|---|---|
| `npx tsc --noEmit` | **pass** (exit 0) |
| `npm run build` (tsup) | **pass** (build success, exit 0) |
| `npm run lint` | **pass** — 6 warnings, 0 errors; identical warning set to `origin/master` (all in untouched `http/*` files + 2 pre-existing `any` warnings in the test file). No new warnings. |
| `npm test` (vitest) | 17 passed, 2 failed. The 2 failures are the **pre-existing network-dependent** `fetch-docs`/`get-anon-key` integration checks (`AssertionError: expected true to be falsy`, backend unreachable at localhost:7130). Confirmed identical failures on a clean `origin/master` checkout in the same environment. The new annotations assertion test **passes**. |

The annotations check was run as an in-suite assertion (no live server needed) since it inspects what the registrar passes to `server.tool`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add MCP tool annotations to all InsForge MCP tools so clients get clear behavior hints (read-only, destructive, idempotent, open-world), improving Agent Integration for INS-306. Annotations are passed positionally between the input schema and the handler per the `@modelcontextprotocol/sdk` overload; the integration test mock now reads the final-argument callback and asserts annotations are present.

<sup>Written for commit db1b5e96864320d5bfcb1a3182a29e727d6da2f7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/insforge-mcp/pull/61?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Enhanced internal tool metadata and descriptions across multiple system tools to improve system clarity and organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->