### PR TITLE
fix: resolve dependency vulnerabilities via npm overrides

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2452,9 +2452,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -3407,9 +3407,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "funding": [
         {
           "type": "github",
@@ -3806,9 +3806,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.16",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.16.tgz",
-      "integrity": "sha512-jN0ZewiNAWSe5khM3EyCmBb250+b40wWbwNILNfEvq84VREWwOIkuUsFONk/3i3nqkz7Oe1PcpM2mwQEK2L9Kg==",
+      "version": "4.12.23",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.23.tgz",
+      "integrity": "sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -3941,9 +3941,9 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -5136,9 +5136,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
-      "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"

--- a/package.json
+++ b/package.json
@@ -58,13 +58,16 @@
     "zod": "^3.23.8"
   },
   "overrides": {
-    "brace-expansion": "^5.0.5",
+    "brace-expansion": "^5.0.6",
+    "fast-uri": "^3.1.2",
     "glob": "^10.5.0",
+    "ip-address": "^10.1.1",
     "minimatch": "^9.0.7",
     "@hono/node-server": "^1.19.13",
-    "hono": "^4.12.14",
+    "hono": "^4.12.18",
     "lodash": "^4.18.0",
     "postcss": "^8.5.10",
+    "qs": "^6.15.2",
     "rollup": "^4.59.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary

Addresses all 8 reported dependency vulnerabilities (transitive deps via `@modelcontextprotocol/sdk`, `eslint`, and `express`) by pinning secure floors through the existing `overrides` block in `package.json`.

| Package | CVE(s) | Before | After |
|---------|--------|--------|-------|
| fast-uri | CVE-2026-6321, CVE-2026-6322 | 3.1.0 | **3.1.2** |
| hono | CVE-2026-44457, CVE-2026-44458, CVE-2026-44459 | 4.12.16 | **4.12.23** |
| ip-address | CVE-2026-42338 | 10.1.0 | **10.2.0** |
| brace-expansion | CVE-2026-45149 | 5.0.5 | **5.0.6** |
| qs | CVE-2026-8723 | 6.15.0 | **6.15.2** |

## Changes
- Bumped `brace-expansion` `^5.0.5` → `^5.0.6` and `hono` `^4.12.14` → `^4.12.18`
- Added new overrides: `fast-uri ^3.1.2`, `ip-address ^10.1.1`, `qs ^6.15.2`
- Regenerated `package-lock.json`

## Verification
- `npm audit` → **0 vulnerabilities**
- `npm run build` → passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes all reported dependency vulnerabilities by pinning safe minimum versions via npm `overrides`. Resolves 8 advisories in transitive deps and brings `npm audit` to 0.

- **Dependencies**
  - Pinned floors via `overrides`: `brace-expansion` >= 5.0.6, `fast-uri` >= 3.1.2, `hono` >= 4.12.18, `ip-address` >= 10.1.1, `qs` >= 6.15.2.
  - Regenerated `package-lock.json`.
  - Result: `npm audit` shows 0 vulnerabilities; `npm run build` passes.

<sup>Written for commit 3dc5f538c161e73121fb41b77f20b6f6d8954387. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/insforge-mcp/pull/62?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated and added dependency version pins to maintain package stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->