### PR TITLE
chore(registry): add branding to glama.json + server.json (INS-306)

### DIFF
--- a/server.json
+++ b/server.json
@@ -3,6 +3,13 @@
   "name": "io.github.InsForge/insforge-mcp",
   "title": "InsForge",
   "description": "MCP server for InsForge BaaS — database, storage, edge functions, and deployments",
+  "websiteUrl": "https://insforge.dev",
+  "icons": [
+    {
+      "src": "https://github.com/InsForge.png",
+      "mimeType": "image/png"
+    }
+  ],
   "repository": {
     "url": "https://github.com/InsForge/insforge-mcp",
     "source": "github"


### PR DESCRIPTION
## What

Metadata hygiene for INS-306 (ora "Registry branding 0/2" — MCP registry entry lacks display name/icon/website). Fills in blank branding fields on the registry manifests, adding **only fields that are valid per each manifest's schema** (schemas verified by fetching them before editing).

## Fields added

**`server.json`** — validated against the official MCP `server.schema.json` (`https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json`, the `$schema` already referenced in the file). Validated with ajv: passes.
- `websiteUrl`: `https://insforge.dev` — schema defines `websiteUrl` ("Optional URL to the server's homepage…").
- `icons`: `[{ "src": "https://github.com/InsForge.png", "mimeType": "image/png" }]` — schema defines `icons` (array of `Icon`; `src` requires an HTTPS URI ≤255 chars, `mimeType` enum includes `image/png`). The logo URL resolves to a `200 image/png` (the InsForge GitHub org avatar).

Unchanged in `server.json`: `name`, `version`, `packages`, `remotes`, `title`, `description`, `repository`.

**`glama.json`** — **not modified.** The Glama schema (`https://glama.ai/mcp/schemas/server.json`) defines exactly one property: `maintainers`. It defines no `description`, `logo`/`icon`, or `website` field. Rather than invent unrecognized fields, glama.json was left as-is. The website/icon branding is carried by `server.json`, where it is schema-defined.

## Notes / honesty

- ora detection depends on the live registries (Glama, the MCP registry) re-indexing this manifest; the PR itself only updates the source manifest.
- The task brief assumed Glama supported `description`/`logo`/`website` fields — its published schema does not, so those were intentionally omitted to avoid inventing fields. If Glama later publishes a richer schema, a follow-up can add them.
- Pre-existing version skew (`package.json` 1.2.10 vs `server.json` 1.2.6) was left untouched per scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add branding to the MCP registry manifest so our entry shows a website and icon in registries, contributing to INS-306’s Agent Readiness goals.
Adds `websiteUrl` and `icons[]` to `server.json` per the MCP schema; leaves `glama.json` unchanged because its schema has no branding fields.

<sup>Written for commit 2b44b193f3a5d5bb9f3750d516b24e8e027e9a8f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/insforge-mcp/pull/63?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added website URL metadata to application configuration
  * Added application icon metadata including source and format specifications

<!-- end of auto-generated comment: release notes by coderabbit.ai -->