### PR TITLE
Revert MCP registry branding (#63)

### DIFF
--- a/server.json
+++ b/server.json
@@ -3,13 +3,6 @@
   "name": "io.github.InsForge/insforge-mcp",
   "title": "InsForge",
   "description": "MCP server for InsForge BaaS — database, storage, edge functions, and deployments",
-  "websiteUrl": "https://insforge.dev",
-  "icons": [
-    {
-      "src": "https://github.com/InsForge.png",
-      "mimeType": "image/png"
-    }
-  ],
   "repository": {
     "url": "https://github.com/InsForge/insforge-mcp",
     "source": "github"


### PR DESCRIPTION
Reverts #63 — backs out the `websiteUrl` + logo `icons` added to `server.json`. Not needed for now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove `websiteUrl` and `icons` from `server.json` to undo #63 and return the manifest to a minimal, standard MCP shape. This supports INS-306 by keeping branding and discovery data in `/.well-known/mcp/server-card.json` and avoiding non‑standard fields in `server.json`.

<sup>Written for commit 530e148889d82b831c288b72fe6cb989904bddcc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/insforge-mcp/pull/64?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed unused website URL and icon fields from the server manifest.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->