### PR TITLE
fix: add CLI version output

### DIFF
--- a/src/http/config.ts
+++ b/src/http/config.ts
@@ -1,11 +1,15 @@
 import 'dotenv/config';
 import { program } from 'commander';
+import { PACKAGE_VERSION } from '../shared/version.js';
 
 // ============================================================================
 // Command Line Arguments
 // ============================================================================
 
 program
+  .name('insforge-mcp-server')
+  .description('HTTP MCP server for Insforge backend-as-a-service')
+  .version(PACKAGE_VERSION, '-v, --version')
   .option('--port <number>', 'Port to run HTTP server on', '3000')
   .option('--host <string>', 'Host to bind to', '127.0.0.1');
 program.parse(process.argv);

--- a/src/http/server.ts
+++ b/src/http/server.ts
@@ -24,6 +24,7 @@ import {
 } from './config.js';
 import { renderProjectSelectionPage } from './templates/project-selection.js';
 import { getAnalyticsService, extractClientInfo } from './analytics.js';
+import { PACKAGE_VERSION } from '../shared/version.js';
 
 // ============================================================================
 // Express App Setup
@@ -134,7 +135,7 @@ app.get(API_ENDPOINTS.health, async (_req: Request, res: Response) => {
   res.json({
     status: 'ok',
     server: 'insforge-mcp',
-    version: '1.0.0',
+    version: PACKAGE_VERSION,
     protocols: {
       streamableHttp: '2025-03-26',
       sse: '2024-11-05 (deprecated)',

--- a/src/http/session-manager.ts
+++ b/src/http/session-manager.ts
@@ -3,6 +3,7 @@ import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/
 import { SSEServerTransport } from '@modelcontextprotocol/sdk/server/sse.js';
 import { getRedisClient } from './redis.js';
 import { registerInsforgeTools } from '../shared/tools/index.js';
+import { PACKAGE_VERSION } from '../shared/version.js';
 
 /**
  * Session data stored in Redis
@@ -72,7 +73,7 @@ export class SessionManager {
     // Create MCP server and register tools first
     const server = new McpServer({
       name: 'insforge-mcp',
-      version: '1.0.0',
+      version: PACKAGE_VERSION,
     });
 
     const toolsConfig = await registerInsforgeTools(server, {
@@ -191,7 +192,7 @@ export class SessionManager {
     // Create new MCP server with stored configuration
     const server = new McpServer({
       name: 'insforge-mcp',
-      version: '1.0.0',
+      version: PACKAGE_VERSION,
     });
 
     await registerInsforgeTools(server, {
@@ -231,7 +232,7 @@ export class SessionManager {
     // Create MCP server and register tools first
     const server = new McpServer({
       name: 'insforge-mcp',
-      version: '1.0.0',
+      version: PACKAGE_VERSION,
     });
 
     const toolsConfig = await registerInsforgeTools(server, {

--- a/src/shared/version.ts
+++ b/src/shared/version.ts
@@ -1,0 +1,3 @@
+import packageJson from '../../package.json';
+
+export const PACKAGE_VERSION = packageJson.version;

--- a/src/shared/version.ts
+++ b/src/shared/version.ts
@@ -9,6 +9,10 @@ function loadPackageJson(): { version?: string } {
   try {
     return require('../../package.json') as { version?: string };
   } catch {
-    return require('../package.json') as { version?: string };
+    try {
+      return require('../package.json') as { version?: string };
+    } catch {
+      return { version: '0.0.0' };
+    }
   }
 }

--- a/src/shared/version.ts
+++ b/src/shared/version.ts
@@ -1,3 +1,14 @@
-import packageJson from '../../package.json';
+import { createRequire } from 'node:module';
 
-export const PACKAGE_VERSION = packageJson.version;
+const require = createRequire(import.meta.url);
+const packageJson = loadPackageJson();
+
+export const PACKAGE_VERSION = packageJson.version ?? '0.0.0';
+
+function loadPackageJson(): { version?: string } {
+  try {
+    return require('../../package.json') as { version?: string };
+  } catch {
+    return require('../package.json') as { version?: string };
+  }
+}

--- a/src/stdio/index.ts
+++ b/src/stdio/index.ts
@@ -1,11 +1,16 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { program } from 'commander';
+import { PACKAGE_VERSION } from '../shared/version.js';
 import { registerInsforgeTools } from '../shared/tools/index.js';
 
 // Parse command line arguments
-program.option('--api_key <value>', 'API Key');
-program.option('--api_base_url <value>', 'API Base URL');
+program
+  .name('insforge-mcp')
+  .description('MCP server for Insforge backend-as-a-service')
+  .version(PACKAGE_VERSION, '-v, --version')
+  .option('--api_key <value>', 'API Key')
+  .option('--api_base_url <value>', 'API Base URL');
 program.parse(process.argv);
 const options = program.opts();
 const { api_key, api_base_url } = options;
@@ -15,7 +20,7 @@ async function main() {
   // Create MCP server
   const server = new McpServer({
     name: 'insforge-mcp',
-    version: '1.0.0',
+    version: PACKAGE_VERSION,
   });
 
   // Register all Insforge tools with the server (async to support dynamic version-based registration)


### PR DESCRIPTION
Closes #66.

Manual validation after the latest update:
- `npm run build`
- `npm test`
- `npm run lint`
- `node dist/index.js --version` -> `1.2.10`
- `node dist/http-server.js --version` -> `1.2.10`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `-v, --version` flag to both CLIs and replaces hardcoded versions with the package version for consistent reporting across the app.

- **New Features**
  - `-v, --version` for `insforge-mcp-server` and `insforge-mcp` CLIs.
  - Added CLI names and descriptions for clearer help output.

- **Refactors**
  - Replaced hardcoded `1.0.0` with `PACKAGE_VERSION` in MCP server init and the HTTP health endpoint.
  - Made version loading bundler-safe in `src/shared/version.ts` using `createRequire`, with a safe fallback to `0.0.0` if `package.json` is unavailable.

<sup>Written for commit c998eda82420298c7ddff9db24d9e8b92aeb0b82. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/insforge-mcp/pull/65?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized application version reporting: CLI, server health endpoint, and session metadata now reflect the package version (no more hardcoded value), ensuring consistent runtime version display.
* **New Features**
  * CLI now advertises command name, description, and version via the standard command-line interface metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->