### PR TITLE
chore(release): align manifests to 1.2.12 — MERGE LAST, after #68/#69/#71 (supersedes #57)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@insforge/mcp",
-  "version": "1.2.10",
+  "version": "1.2.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@insforge/mcp",
-      "version": "1.2.10",
+      "version": "1.2.12",
       "license": "Apache-2.0",
       "dependencies": {
         "@insforge/shared-schemas": "1.1.49",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@insforge/mcp",
-  "version": "1.2.10",
+  "version": "1.2.12",
   "description": "MCP (Model Context Protocol) server for Insforge backend-as-a-service",
   "mcpName": "io.github.InsForge/insforge-mcp",
   "type": "module",

--- a/server.json
+++ b/server.json
@@ -14,7 +14,7 @@
     "url": "https://github.com/InsForge/insforge-mcp",
     "source": "github"
   },
-  "version": "1.2.6",
+  "version": "1.2.12",
   "remotes": [
     {
       "type": "streamable-http",
@@ -25,7 +25,7 @@
     {
       "registryType": "npm",
       "identifier": "@insforge/mcp",
-      "version": "1.2.6",
+      "version": "1.2.12",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
Closes out the version drift. **Supersedes #57 — that PR should be closed rather than merged**, for the reason below.

## ⚠️ Draft on purpose: merge order matters

This PR is manifests-only, so it looks like a safe quick merge. It isn't, under an artifact deploy:

**`#68` → `#69` → `#71` → then this → then publish `1.2.12` once → deploy that exact version.**

If this merges and `1.2.12` is published *before* #69 lands, the artifact we install is `1.2.12` without the discovery fix, the post-deploy check fails on its first assertion, and recovering needs a `1.2.13` and a second publish. `npm publish` reads the version from `package.json`, so this must land *before* the publish, but *after* the fixes it is meant to label.

If anything publishes to npm in the meantime, this becomes `1.2.13` — I'll bump it before taking it out of draft.

## The drift, measured

| Where | Version |
|---|---|
| Public MCP registry (`registry.modelcontextprotocol.io`) | **1.2.6** |
| npm `@insforge/mcp` latest | **1.2.11** |
| `master` `package.json` | 1.2.10 |
| `master` `server.json` | 1.2.6 |

The registry entry is generated from `server.json`, which is why it's five versions behind. Confirmed by querying the registry directly.

## Why 1.2.12 and not 1.2.11

#57 proposed 1.2.11. It branched at `649b586`; `master` has **15 commits since**, including code that is *not* in the published 1.2.11 tarball:

- `fe54a21` CLI `--version` output
- `f301317` / `c998eda` bundler-safe package-version loading
- `2b44b19` `server.json` registry branding
- three dependency-override security fixes

Verified by unpacking `@insforge/mcp@1.2.11`: its `server.json` has no `icons`, and its `dist/index.js` has no `-v, --version`. Merging #57 would put two different builds behind one published version number.

`1.2.12` is unused on npm (checked against the full 78-version list).

## Verification

- `1.2.12` reaches every surface that reports a version: `dist/index.js --version`, `dist/http-server.js --version`, and `GET /health` — all three report `1.2.12`.
- 18/18 vitest, eslint clean, build succeeds.
- `server.json` edited surgically so the em-dash in `description` survives — a naive JSON round-trip escapes it.

## Scope

Manifests only. **This does not publish anything.** Shipping `1.2.12` to npm and re-publishing `server.json` to the MCP registry are separate steps that need a human, and merging this alone does not move the registry entry.

## Interaction with #64

#64 (revert registry branding) also touches `server.json`, but different lines — no textual conflict either way round.

🤖 Generated with [Claude Code](https://claude.com/claude-code)