### PR TITLE
fix(http): reap orphaned runtime sessions and keep SSE streams alive

### DIFF
--- a/src/http/config.ts
+++ b/src/http/config.ts
@@ -98,6 +98,19 @@ export const REDIS_CONFIG = {
 // Session Configuration
 // ============================================================================
 
+/**
+ * How often to write a comment frame on an idle SSE stream. Must stay well
+ * under the load balancer's idle timeout (60s by default on an AWS ALB) or the
+ * stream is closed underneath a connected client.
+ */
+export const SSE_KEEPALIVE_MS = parseInt(process.env.MCP_SSE_KEEPALIVE_MS || '') || 25 * 1000;
+
+/**
+ * How often to reap runtime sessions whose Redis record has expired.
+ * Overridable so the reaper can be exercised without waiting minutes.
+ */
+export const SESSION_SWEEP_MS = parseInt(process.env.MCP_SESSION_SWEEP_MS || '') || 5 * 60 * 1000;
+
 export const SESSION_CONFIG = {
   /** Session TTL in seconds (24 hours) */
   ttl: 24 * 60 * 60,

--- a/src/http/config.ts
+++ b/src/http/config.ts
@@ -99,17 +99,27 @@ export const REDIS_CONFIG = {
 // ============================================================================
 
 /**
+ * Positive-integer env override. A zero, a negative or an unparseable value
+ * falls back to the default rather than reaching setInterval, which clamps a
+ * non-positive delay to 1ms and would spin.
+ */
+export function positiveIntEnv(value: string | undefined, fallback: number): number {
+  const parsed = parseInt(value || '', 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+/**
  * How often to write a comment frame on an idle SSE stream. Must stay well
  * under the load balancer's idle timeout (60s by default on an AWS ALB) or the
  * stream is closed underneath a connected client.
  */
-export const SSE_KEEPALIVE_MS = parseInt(process.env.MCP_SSE_KEEPALIVE_MS || '') || 25 * 1000;
+export const SSE_KEEPALIVE_MS = positiveIntEnv(process.env.MCP_SSE_KEEPALIVE_MS, 25 * 1000);
 
 /**
  * How often to reap runtime sessions whose Redis record has expired.
  * Overridable so the reaper can be exercised without waiting minutes.
  */
-export const SESSION_SWEEP_MS = parseInt(process.env.MCP_SESSION_SWEEP_MS || '') || 5 * 60 * 1000;
+export const SESSION_SWEEP_MS = positiveIntEnv(process.env.MCP_SESSION_SWEEP_MS, 5 * 60 * 1000);
 
 export const SESSION_CONFIG = {
   /** Session TTL in seconds (24 hours) */

--- a/src/http/keepalive.test.ts
+++ b/src/http/keepalive.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect, vi, afterEach, type Mock } from 'vitest';
+import { positiveIntEnv } from './config.js';
+
+/**
+ * The keepalive itself is a few lines inline in the SSE handler, and server.ts
+ * calls startServer() at import time so it can't be imported here. These cover
+ * the behaviour that matters — write on tick, stop on close, never write to a
+ * finished response — against the same shape the handler uses, plus the env
+ * parsing that decides the interval.
+ */
+
+type FakeRes = {
+  writableEnded: boolean;
+  write: Mock<(chunk: string) => void>;
+  handlers: Record<string, () => void>;
+  on: (event: string, fn: () => void) => void;
+  emit: (event: string) => void;
+};
+
+function fakeRes(): FakeRes {
+  const res: FakeRes = {
+    writableEnded: false,
+    write: vi.fn<(chunk: string) => void>(),
+    handlers: {},
+    on(event, fn) {
+      res.handlers[event] = fn;
+    },
+    emit(event) {
+      res.handlers[event]?.();
+    },
+  };
+  return res;
+}
+
+/** Mirrors the handler: start an interval, clear it when the response closes. */
+function attachKeepAlive(res: FakeRes, intervalMs: number) {
+  const timer = setInterval(() => {
+    if (res.writableEnded) return;
+    try {
+      res.write(': keepalive\n\n');
+    } catch {
+      /* handler logs; irrelevant here */
+    }
+  }, intervalMs);
+  timer.unref?.();
+  res.on('close', () => clearInterval(timer));
+  return timer;
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('SSE keepalive', () => {
+  it('writes a comment frame on each tick', () => {
+    vi.useFakeTimers();
+    const res = fakeRes();
+    attachKeepAlive(res, 1000);
+
+    vi.advanceTimersByTime(3000);
+
+    expect(res.write).toHaveBeenCalledTimes(3);
+    // A comment frame: ignored by the event-stream parser, so it cannot be
+    // mistaken for protocol traffic by a client.
+    expect(res.write).toHaveBeenCalledWith(': keepalive\n\n');
+  });
+
+  it('stops writing once the response closes', () => {
+    vi.useFakeTimers();
+    const res = fakeRes();
+    attachKeepAlive(res, 1000);
+
+    vi.advanceTimersByTime(2000);
+    expect(res.write).toHaveBeenCalledTimes(2);
+
+    res.emit('close');
+    vi.advanceTimersByTime(10000);
+
+    expect(res.write).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not write to a response that has already ended', () => {
+    vi.useFakeTimers();
+    const res = fakeRes();
+    attachKeepAlive(res, 1000);
+
+    res.writableEnded = true;
+    vi.advanceTimersByTime(5000);
+
+    expect(res.write).not.toHaveBeenCalled();
+  });
+
+  it('keeps ticking when a write throws', () => {
+    vi.useFakeTimers();
+    const res = fakeRes();
+    res.write.mockImplementation(() => {
+      throw new Error('EPIPE');
+    });
+    attachKeepAlive(res, 1000);
+
+    expect(() => vi.advanceTimersByTime(3000)).not.toThrow();
+    expect(res.write).toHaveBeenCalledTimes(3);
+  });
+});
+
+describe('positiveIntEnv', () => {
+  it('uses the fallback when unset', () => {
+    expect(positiveIntEnv(undefined, 25_000)).toBe(25_000);
+  });
+
+  it('accepts a positive override', () => {
+    expect(positiveIntEnv('1500', 25_000)).toBe(1500);
+  });
+
+  it.each(['-1', '0', 'abc', '', '  '])(
+    'falls back for %j rather than passing it to setInterval',
+    (value) => {
+      // setInterval clamps a non-positive delay to 1ms, which would spin
+      // writing keepalive frames as fast as the event loop allows.
+      expect(positiveIntEnv(value, 25_000)).toBe(25_000);
+    }
+  );
+
+  it('ignores trailing junk the way parseInt does, but still demands a number', () => {
+    expect(positiveIntEnv('1500ms', 25_000)).toBe(1500);
+    expect(positiveIntEnv('ms1500', 25_000)).toBe(25_000);
+  });
+});

--- a/src/http/server.ts
+++ b/src/http/server.ts
@@ -1083,6 +1083,16 @@ app.post(SSE_ENDPOINTS.messages, async (req: Request, res: Response) => {
     });
   }
 
+  // Streamable HTTP refreshes the Redis record on every request; the SSE path
+  // did not, so an SSE record lapsed 24h after creation however active the
+  // client was, and /health under-reported live SSE sessions. Fire-and-forget:
+  // a failed refresh must not fail the message.
+  getSessionManager()
+    .touchSession(sessionId)
+    .catch((error) => {
+      console.error(`[SSE] Failed to refresh session ${sessionId}:`, error);
+    });
+
   await transport.handlePostMessage(req, res, req.body);
 });
 

--- a/src/http/server.ts
+++ b/src/http/server.ts
@@ -1,6 +1,7 @@
 import 'dotenv/config';
 import express, { Request, Response, NextFunction } from 'express';
 import { randomUUID, createHash } from 'crypto';
+import v8 from 'node:v8';
 
 // Transport imports
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
@@ -126,6 +127,25 @@ function extractLegacyHeaders(req: Request): { apiKey?: string; apiBaseUrl?: str
   };
 }
 
+/**
+ * Heap numbers for the health payload.
+ *
+ * The session leak had to be diagnosed by counting objects and multiplying by
+ * a separately-measured size, because the process publishes no memory metric
+ * at all — so "how long until it dies" could only ever be an estimate. V8's
+ * own limit is the number that actually decides that, and exposing it costs
+ * nothing.
+ */
+function heapStats() {
+  const { heap_size_limit, used_heap_size } = v8.getHeapStatistics();
+  return {
+    heapUsedMb: Math.round(used_heap_size / 1024 / 1024),
+    heapLimitMb: Math.round(heap_size_limit / 1024 / 1024),
+    heapUsedPct: Math.round((used_heap_size / heap_size_limit) * 100),
+    rssMb: Math.round(process.memoryUsage().rss / 1024 / 1024),
+  };
+}
+
 // ============================================================================
 // Health & Discovery Endpoints
 // ============================================================================
@@ -143,6 +163,7 @@ app.get(API_ENDPOINTS.health, async (_req: Request, res: Response) => {
       sse: '2024-11-05 (deprecated)',
     },
     sessions: stats,
+    memory: heapStats(),
     authentication: 'OAuth Bearer Token',
   });
 });

--- a/src/http/server.ts
+++ b/src/http/server.ts
@@ -16,6 +16,8 @@ import {
   OAUTH_CONFIG,
   STREAMABLE_HTTP_ENDPOINTS,
   SSE_ENDPOINTS,
+  SSE_KEEPALIVE_MS,
+  SESSION_SWEEP_MS,
   OAUTH_ENDPOINTS,
   API_ENDPOINTS,
   isOAuthConfigured,
@@ -978,9 +980,24 @@ app.get(SSE_ENDPOINTS.sse, async (req: Request, res: Response) => {
 
   console.log(`[SSE] Session created: ${transport.sessionId}, Project: ${validProjectInfo.projectName}`);
 
+  // An idle SSE stream carries no bytes, so the load balancer closes it on its
+  // idle timeout and the client sees the connection drop. A comment frame is
+  // ignored by the event-stream parser and by the transport's own framing, so
+  // it keeps the connection warm without being visible to the client.
+  const keepAlive = setInterval(() => {
+    if (res.writableEnded) return;
+    try {
+      res.write(': keepalive\n\n');
+    } catch (error) {
+      console.error(`[SSE] Keepalive write failed for ${transport.sessionId}:`, error);
+    }
+  }, SSE_KEEPALIVE_MS);
+  keepAlive.unref();
+
   // Clean up on close
   res.on('close', () => {
     console.log(`[SSE] Session closed: ${transport.sessionId}`);
+    clearInterval(keepAlive);
     sseTransports.delete(transport.sessionId);
 
     // Clean up the session from SessionManager (async with error handling)
@@ -1083,6 +1100,10 @@ async function startServer() {
     await redis.ping();
     console.log('[Redis] Connection verified');
 
+    // Runtime sessions are only dropped on an explicit DELETE, which Streamable
+    // HTTP clients rarely send. Reap the ones Redis has already expired.
+    getSessionManager().startIdleSweep(SESSION_SWEEP_MS);
+
     const server = app.listen(SERVER_CONFIG.port, SERVER_CONFIG.host, () => {
       const redisConfig = getRedisConfig();
       console.log(`
@@ -1166,6 +1187,7 @@ async function startServer() {
         // Close all MCP sessions
         try {
           const sessionManager = getSessionManager();
+          sessionManager.stopIdleSweep();
           await sessionManager.closeAllSessions();
         } catch (error) {
           console.error('[Shutdown] Error closing sessions:', error);

--- a/src/http/server.ts
+++ b/src/http/server.ts
@@ -899,6 +899,13 @@ app.get(STREAMABLE_HTTP_ENDPOINTS.mcp, async (req: Request, res: Response) => {
     });
   }
 
+  // This stream is the only sign of life for a client that opens it and then
+  // sends nothing. Hold the session for as long as it is open, and restart the
+  // Redis record's clock now so a restart can still restore the session.
+  sessionManager.openStream(sessionId);
+  res.on('close', () => sessionManager.closeStream(sessionId));
+  await sessionManager.touchSession(sessionId);
+
   await runtime.transport.handleRequest(req, res, req.body);
 });
 

--- a/src/http/server.ts
+++ b/src/http/server.ts
@@ -1118,7 +1118,7 @@ app.post(SSE_ENDPOINTS.messages, async (req: Request, res: Response) => {
   getSessionManager()
     .touchSession(sessionId)
     .catch((error) => {
-      console.error(`[SSE] Failed to refresh session ${sessionId}:`, error);
+      console.error(`[SSE] Failed to refresh session ${tokenFingerprint(sessionId)}`, error);
     });
 
   await transport.handlePostMessage(req, res, req.body);

--- a/src/http/session-manager.test.ts
+++ b/src/http/session-manager.test.ts
@@ -15,7 +15,13 @@ vi.mock('./redis.js', () => ({
   }),
 }));
 
-const { SessionManager, selectOrphanedSessions, SESSION_TTL_MS, monotonicNow } = await import('./session-manager.js');
+const {
+  SessionManager,
+  selectOrphanedSessions,
+  selectPrematurelyMissing,
+  SESSION_TTL_MS,
+  monotonicNow,
+} = await import('./session-manager.js');
 
 /** A session whose last traffic is old enough that its record should have expired. */
 const STALE = -(SESSION_TTL_MS + 1000);
@@ -29,6 +35,7 @@ function fakeRuntime(transportType: 'streamable' | 'sse' = 'streamable', ageOffs
     transport: { close: vi.fn().mockResolvedValue(undefined) },
     transportType,
     lastSeenAt: monotonicNow() + ageOffsetMs,
+    openStreams: 0,
   };
 }
 
@@ -52,7 +59,7 @@ describe('selectOrphanedSessions', () => {
   const now = 1_800_000_000_000;
   /** Sessions whose records should already have expired on their own. */
   const aged = (...ids: string[]) =>
-    ids.map((sessionId) => ({ sessionId, lastSeenAt: now - SESSION_TTL_MS - 1000 }));
+    ids.map((sessionId) => ({ sessionId, lastSeenAt: now - SESSION_TTL_MS - 1000, openStreams: 0 }));
 
   it('picks exactly the ids whose Redis record is gone', () => {
     expect(selectOrphanedSessions(aged('a', 'b', 'c'), [1, 0, 1], now)).toEqual(['b']);
@@ -68,21 +75,63 @@ describe('selectOrphanedSessions', () => {
 
   it('holds a session whose record vanished well inside its TTL', () => {
     // Redis losing data, not Redis expiring a session.
-    const active = [{ sessionId: 'busy', lastSeenAt: now - 60_000 }];
+    const active = [{ sessionId: 'busy', lastSeenAt: now - 60_000, openStreams: 0 }];
     expect(selectOrphanedSessions(active, [0], now)).toEqual([]);
   });
 
   it('separates the wiped-but-active from the genuinely abandoned', () => {
     const mixed = [
-      { sessionId: 'active', lastSeenAt: now - 60_000 },
-      { sessionId: 'abandoned', lastSeenAt: now - SESSION_TTL_MS - 1 },
+      { sessionId: 'active', lastSeenAt: now - 60_000, openStreams: 0 },
+      { sessionId: 'abandoned', lastSeenAt: now - SESSION_TTL_MS - 1, openStreams: 0 },
     ];
     expect(selectOrphanedSessions(mixed, [0, 0], now)).toEqual(['abandoned']);
   });
 
+  it('holds a session with an open stream, however old both clocks are', () => {
+    // The client is plainly connected — it just has nothing to say.
+    const streaming = [
+      { sessionId: 'listening', lastSeenAt: now - SESSION_TTL_MS * 10, openStreams: 1 },
+    ];
+    expect(selectOrphanedSessions(streaming, [0], now)).toEqual([]);
+  });
+
+  it('reaps once the last stream has closed', () => {
+    const closed = [
+      { sessionId: 'was-listening', lastSeenAt: now - SESSION_TTL_MS - 1, openStreams: 0 },
+    ];
+    expect(selectOrphanedSessions(closed, [0], now)).toEqual(['was-listening']);
+  });
+
   it('reaps a session exactly at the TTL boundary', () => {
-    const boundary = [{ sessionId: 'edge', lastSeenAt: now - SESSION_TTL_MS }];
+    const boundary = [{ sessionId: 'edge', lastSeenAt: now - SESSION_TTL_MS, openStreams: 0 }];
     expect(selectOrphanedSessions(boundary, [0], now)).toEqual(['edge']);
+  });
+});
+
+describe('selectPrematurelyMissing', () => {
+  const now = 1_800_000_000_000;
+
+  it('flags a record that vanished while the session was still inside its TTL', () => {
+    const s = [{ sessionId: 'busy', lastSeenAt: now - 60_000, openStreams: 0 }];
+    expect(selectPrematurelyMissing(s, [0], now)).toEqual(['busy']);
+  });
+
+  it('says nothing about a record that expired on schedule', () => {
+    // Normal expiry is not evidence of anything and must not send an operator
+    // looking for a Redis fault.
+    const s = [{ sessionId: 'old', lastSeenAt: now - SESSION_TTL_MS - 1, openStreams: 0 }];
+    expect(selectPrematurelyMissing(s, [0], now)).toEqual([]);
+  });
+
+  it('does not flag a long-open stream whose record expired normally', () => {
+    // Held by its stream, not by the TTL gate — so it is not a Redis symptom.
+    const s = [{ sessionId: 'listening', lastSeenAt: now - SESSION_TTL_MS - 1, openStreams: 1 }];
+    expect(selectPrematurelyMissing(s, [0], now)).toEqual([]);
+  });
+
+  it('says nothing when the records are present', () => {
+    const s = [{ sessionId: 'fine', lastSeenAt: now - 60_000, openStreams: 0 }];
+    expect(selectPrematurelyMissing(s, [1], now)).toEqual([]);
   });
 });
 
@@ -181,6 +230,59 @@ describe('SessionManager.sweepOrphanedSessions', () => {
 
     await expect(manager.sweepOrphanedSessions()).resolves.toBe(45);
     expect(manager.getActiveSessionIds()).toHaveLength(5);
+  });
+
+  it('never reaps a streamable session while its stream is open', async () => {
+    // Quinn's case: the client holds GET /mcp open and sends no POSTs, so the
+    // Redis record lapses and lastSeenAt is frozen at the moment it opened.
+    // Both clocks agree to reap a client that is still connected.
+    const manager = new SessionManager();
+    const runtimes = seed(manager, ['listening'], 'streamable', STALE);
+    manager.openStream('listening');
+    pipelineExec.mockResolvedValue([[null, 0]]);
+
+    await expect(manager.sweepOrphanedSessions()).resolves.toBe(0);
+    expect(manager.getActiveSessionIds()).toEqual(['listening']);
+    expect(runtimes.get('listening')!.transport.close).not.toHaveBeenCalled();
+  });
+
+  it('collects the session once the stream closes and it goes idle', async () => {
+    const manager = new SessionManager();
+    seed(manager, ['listening'], 'streamable', STALE);
+    manager.openStream('listening');
+    manager.closeStream('listening');
+    // closeStream restarts the idle clock, so it is not immediately collectable.
+    pipelineExec.mockResolvedValue([[null, 0]]);
+    await expect(manager.sweepOrphanedSessions()).resolves.toBe(0);
+
+    // Age it past the TTL again and it goes, exactly as an idle session should.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (manager as any).runtimeSessions.get('listening').lastSeenAt = monotonicNow() + STALE;
+    pipelineExec.mockResolvedValue([[null, 0]]);
+    await expect(manager.sweepOrphanedSessions()).resolves.toBe(1);
+    expect(manager.getActiveSessionIds()).toEqual([]);
+  });
+
+  it('counts overlapping streams so a reconnect cannot unprotect the session', async () => {
+    // A client may open its replacement stream before the old response has
+    // finished closing. A boolean flag cleared by the departing one would drop
+    // the guard while a live stream is still attached.
+    const manager = new SessionManager();
+    seed(manager, ['reconnecting'], 'streamable', STALE);
+    manager.openStream('reconnecting');
+    manager.openStream('reconnecting');
+    manager.closeStream('reconnecting');
+    expect(manager.getOpenStreamCount('reconnecting')).toBe(1);
+
+    pipelineExec.mockResolvedValue([[null, 0]]);
+    await expect(manager.sweepOrphanedSessions()).resolves.toBe(0);
+  });
+
+  it('ignores a stream close for a session that is already gone', async () => {
+    // Close events land after a reap or an explicit DELETE all the time.
+    const manager = new SessionManager();
+    expect(() => manager.closeStream('never-existed')).not.toThrow();
+    expect(manager.getOpenStreamCount('never-existed')).toBe(0);
   });
 
   it('keeps every session when Redis comes back empty', async () => {

--- a/src/http/session-manager.test.ts
+++ b/src/http/session-manager.test.ts
@@ -14,19 +14,19 @@ vi.mock('./redis.js', () => ({
 const { SessionManager, selectOrphanedSessions } = await import('./session-manager.js');
 
 /** Stand-in for a runtime entry; only close() is exercised by the sweep. */
-function fakeRuntime() {
+function fakeRuntime(transportType: 'streamable' | 'sse' = 'streamable') {
   return {
     server: { close: vi.fn().mockResolvedValue(undefined) },
     transport: { close: vi.fn().mockResolvedValue(undefined) },
-    transportType: 'streamable' as const,
+    transportType,
   };
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-function seed(manager: any, ids: string[]) {
+function seed(manager: any, ids: string[], transportType: 'streamable' | 'sse' = 'streamable') {
   const runtimes = new Map<string, ReturnType<typeof fakeRuntime>>();
   for (const id of ids) {
-    const rt = fakeRuntime();
+    const rt = fakeRuntime(transportType);
     runtimes.set(id, rt);
     manager.runtimeSessions.set(id, rt);
   }
@@ -97,6 +97,38 @@ describe('SessionManager.sweepOrphanedSessions', () => {
 
     await expect(manager.sweepOrphanedSessions()).resolves.toBe(0);
     expect(manager.getActiveSessionIds()).toEqual(['a']);
+  });
+
+  it('never reaps an SSE session, even with no Redis record', async () => {
+    // SSE cleans up on res 'close' and nothing on its message path used to
+    // refresh the record, so an SSE record lapses at TTL from creation while
+    // the connection is still open and keepalive-warm. Sweeping it would drop
+    // a live client.
+    const manager = new SessionManager();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const sse = seed(manager as any, ['sse-live'], 'sse');
+    pipelineExec.mockResolvedValue([[null, 0]]);
+
+    await expect(manager.sweepOrphanedSessions()).resolves.toBe(0);
+    expect(manager.getActiveSessionIds()).toContain('sse-live');
+    expect(sse.get('sse-live')!.transport.close).not.toHaveBeenCalled();
+    // Nothing to ask Redis about, so no pipeline should have run at all.
+    expect(pipelineExec).not.toHaveBeenCalled();
+  });
+
+  it('reaps an expired streamable session while leaving an SSE one alone', async () => {
+    const manager = new SessionManager();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const streamable = seed(manager as any, ['http-dead'], 'streamable');
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const sse = seed(manager as any, ['sse-live'], 'sse');
+    // Only the streamable id is queried, so a single reply is correct.
+    pipelineExec.mockResolvedValue([[null, 0]]);
+
+    await expect(manager.sweepOrphanedSessions()).resolves.toBe(1);
+    expect(manager.getActiveSessionIds()).toEqual(['sse-live']);
+    expect(streamable.get('http-dead')!.transport.close).toHaveBeenCalled();
+    expect(sse.get('sse-live')!.transport.close).not.toHaveBeenCalled();
   });
 
   it('reclaims an accumulation of orphans in one pass', async () => {

--- a/src/http/session-manager.test.ts
+++ b/src/http/session-manager.test.ts
@@ -380,3 +380,61 @@ describe('SessionManager idle sweep timer', () => {
     logged.mockRestore();
   });
 });
+
+describe('EXISTS replies that are not a number', () => {
+  beforeEach(() => {
+    pipelineExec.mockReset();
+    redisDel.mockReset().mockResolvedValue(1);
+    redisGet.mockReset().mockResolvedValue(null);
+    redisSetex.mockReset().mockResolvedValue('OK');
+  });
+
+  it('treats a null reply as alive, not as an expired session', async () => {
+    // Number(null) is 0, so a bare cast turns "Redis said something odd" into
+    // "reap this". EXISTS answers with an integer or nothing useful at all.
+    const manager = new SessionManager();
+    seed(manager, ['a', 'b'], 'streamable', STALE);
+    pipelineExec.mockResolvedValue([
+      [null, null],
+      [null, undefined],
+    ]);
+
+    await expect(manager.sweepOrphanedSessions()).resolves.toBe(0);
+    expect(manager.getActiveSessionIds()).toEqual(['a', 'b']);
+  });
+
+  it('still reaps on an honest zero', async () => {
+    const manager = new SessionManager();
+    seed(manager, ['gone'], 'streamable', STALE);
+    pipelineExec.mockResolvedValue([[null, 0]]);
+
+    await expect(manager.sweepOrphanedSessions()).resolves.toBe(1);
+  });
+});
+
+describe('a session touched between the EXISTS round trip and the delete', () => {
+  beforeEach(() => {
+    pipelineExec.mockReset();
+    redisDel.mockReset().mockResolvedValue(1);
+    redisGet.mockReset().mockResolvedValue(null);
+    redisSetex.mockReset().mockResolvedValue('OK');
+  });
+
+  it('is not closed, because the live entry is re-checked', async () => {
+    // The candidate list is a snapshot taken before the pipeline. A request
+    // arriving in that window stamps lastSeenAt and rewrites the record, so
+    // acting on the snapshot would close a session that just proved it is live.
+    const manager = new SessionManager();
+    const runtimes = seed(manager, ['racing'], 'streamable', STALE);
+
+    pipelineExec.mockImplementation(async () => {
+      // The request lands while Redis is answering.
+      await manager.touchSession('racing');
+      return [[null, 0]];
+    });
+
+    await expect(manager.sweepOrphanedSessions()).resolves.toBe(0);
+    expect(manager.getActiveSessionIds()).toEqual(['racing']);
+    expect(runtimes.get('racing')!.transport.close).not.toHaveBeenCalled();
+  });
+});

--- a/src/http/session-manager.test.ts
+++ b/src/http/session-manager.test.ts
@@ -3,30 +3,45 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 const pipelineExec = vi.fn();
 const pipelineExists = vi.fn();
 const redisDel = vi.fn();
+const redisGet = vi.fn();
+const redisSetex = vi.fn();
 
 vi.mock('./redis.js', () => ({
   getRedisClient: () => ({
     pipeline: () => ({ exists: pipelineExists, exec: pipelineExec }),
     del: redisDel,
+    get: redisGet,
+    setex: redisSetex,
   }),
 }));
 
-const { SessionManager, selectOrphanedSessions } = await import('./session-manager.js');
+const { SessionManager, selectOrphanedSessions, SESSION_TTL_MS, monotonicNow } = await import('./session-manager.js');
+
+/** A session whose last traffic is old enough that its record should have expired. */
+const STALE = -(SESSION_TTL_MS + 1000);
+/** A session that served traffic a minute ago. */
+const FRESH = -60_000;
 
 /** Stand-in for a runtime entry; only close() is exercised by the sweep. */
-function fakeRuntime(transportType: 'streamable' | 'sse' = 'streamable') {
+function fakeRuntime(transportType: 'streamable' | 'sse' = 'streamable', ageOffsetMs = STALE) {
   return {
     server: { close: vi.fn().mockResolvedValue(undefined) },
     transport: { close: vi.fn().mockResolvedValue(undefined) },
     transportType,
+    lastSeenAt: monotonicNow() + ageOffsetMs,
   };
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-function seed(manager: any, ids: string[], transportType: 'streamable' | 'sse' = 'streamable') {
+function seed(
+  manager: any,
+  ids: string[],
+  transportType: 'streamable' | 'sse' = 'streamable',
+  ageOffsetMs = STALE
+) {
   const runtimes = new Map<string, ReturnType<typeof fakeRuntime>>();
   for (const id of ids) {
-    const rt = fakeRuntime(transportType);
+    const rt = fakeRuntime(transportType, ageOffsetMs);
     runtimes.set(id, rt);
     manager.runtimeSessions.set(id, rt);
   }
@@ -34,16 +49,40 @@ function seed(manager: any, ids: string[], transportType: 'streamable' | 'sse' =
 }
 
 describe('selectOrphanedSessions', () => {
+  const now = 1_800_000_000_000;
+  /** Sessions whose records should already have expired on their own. */
+  const aged = (...ids: string[]) =>
+    ids.map((sessionId) => ({ sessionId, lastSeenAt: now - SESSION_TTL_MS - 1000 }));
+
   it('picks exactly the ids whose Redis record is gone', () => {
-    expect(selectOrphanedSessions(['a', 'b', 'c'], [1, 0, 1])).toEqual(['b']);
+    expect(selectOrphanedSessions(aged('a', 'b', 'c'), [1, 0, 1], now)).toEqual(['b']);
   });
 
   it('treats a non-zero reply as alive', () => {
-    expect(selectOrphanedSessions(['a', 'b'], [1, 1])).toEqual([]);
+    expect(selectOrphanedSessions(aged('a', 'b'), [1, 1], now)).toEqual([]);
   });
 
   it('reaps nothing when every record is present', () => {
-    expect(selectOrphanedSessions(['a'], [1])).toEqual([]);
+    expect(selectOrphanedSessions(aged('a'), [1], now)).toEqual([]);
+  });
+
+  it('holds a session whose record vanished well inside its TTL', () => {
+    // Redis losing data, not Redis expiring a session.
+    const active = [{ sessionId: 'busy', lastSeenAt: now - 60_000 }];
+    expect(selectOrphanedSessions(active, [0], now)).toEqual([]);
+  });
+
+  it('separates the wiped-but-active from the genuinely abandoned', () => {
+    const mixed = [
+      { sessionId: 'active', lastSeenAt: now - 60_000 },
+      { sessionId: 'abandoned', lastSeenAt: now - SESSION_TTL_MS - 1 },
+    ];
+    expect(selectOrphanedSessions(mixed, [0, 0], now)).toEqual(['abandoned']);
+  });
+
+  it('reaps a session exactly at the TTL boundary', () => {
+    const boundary = [{ sessionId: 'edge', lastSeenAt: now - SESSION_TTL_MS }];
+    expect(selectOrphanedSessions(boundary, [0], now)).toEqual(['edge']);
   });
 });
 
@@ -52,6 +91,8 @@ describe('SessionManager.sweepOrphanedSessions', () => {
     pipelineExec.mockReset();
     pipelineExists.mockReset();
     redisDel.mockReset().mockResolvedValue(1);
+    redisGet.mockReset().mockResolvedValue(null);
+    redisSetex.mockReset().mockResolvedValue('OK');
   });
 
   it('is a no-op with nothing in memory', async () => {
@@ -140,6 +181,60 @@ describe('SessionManager.sweepOrphanedSessions', () => {
 
     await expect(manager.sweepOrphanedSessions()).resolves.toBe(45);
     expect(manager.getActiveSessionIds()).toHaveLength(5);
+  });
+
+  it('keeps every session when Redis comes back empty', async () => {
+    // Redis restarted without persistence, failed over cold, or evicted: EXISTS
+    // is 0 for all of them at once. Without the age gate this pass closes every
+    // live connection on the box.
+    const manager = new SessionManager();
+    const ids = ['a', 'b', 'c'];
+    const runtimes = seed(manager, ids, 'streamable', FRESH);
+    pipelineExec.mockResolvedValue(ids.map(() => [null, 0]));
+    const warned = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    await expect(manager.sweepOrphanedSessions()).resolves.toBe(0);
+    expect(manager.getActiveSessionIds()).toEqual(ids);
+    for (const id of ids) {
+      expect(runtimes.get(id)!.transport.close).not.toHaveBeenCalled();
+    }
+    // The operator has to hear about it — those records are not coming back.
+    expect(warned).toHaveBeenCalled();
+    warned.mockRestore();
+  });
+
+  it('still collects abandoned sessions after a wipe', async () => {
+    // The wipe must not become a blanket amnesty: anything past its TTL is an
+    // orphan whether Redis expired the record or lost it.
+    const manager = new SessionManager();
+    seed(manager, ['busy'], 'streamable', FRESH);
+    seed(manager, ['abandoned'], 'streamable', STALE);
+    pipelineExec.mockResolvedValue([
+      [null, 0],
+      [null, 0],
+    ]);
+    const warned = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    await expect(manager.sweepOrphanedSessions()).resolves.toBe(1);
+    expect(manager.getActiveSessionIds()).toEqual(['busy']);
+    warned.mockRestore();
+  });
+
+  it('a touch protects a session even when Redis has no record to rewrite', async () => {
+    // touchSession only rewrites a record it can still read, so after a wipe
+    // the in-memory stamp is the sole evidence the client is active.
+    const manager = new SessionManager();
+    seed(manager, ['revived'], 'streamable', STALE);
+    redisGet.mockResolvedValue(null);
+
+    await manager.touchSession('revived');
+    expect(redisSetex).not.toHaveBeenCalled();
+
+    pipelineExec.mockResolvedValue([[null, 0]]);
+    const warned = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    await expect(manager.sweepOrphanedSessions()).resolves.toBe(0);
+    expect(manager.getActiveSessionIds()).toEqual(['revived']);
+    warned.mockRestore();
   });
 });
 

--- a/src/http/session-manager.test.ts
+++ b/src/http/session-manager.test.ts
@@ -1,0 +1,153 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const pipelineExec = vi.fn();
+const pipelineExists = vi.fn();
+const redisDel = vi.fn();
+
+vi.mock('./redis.js', () => ({
+  getRedisClient: () => ({
+    pipeline: () => ({ exists: pipelineExists, exec: pipelineExec }),
+    del: redisDel,
+  }),
+}));
+
+const { SessionManager, selectOrphanedSessions } = await import('./session-manager.js');
+
+/** Stand-in for a runtime entry; only close() is exercised by the sweep. */
+function fakeRuntime() {
+  return {
+    server: { close: vi.fn().mockResolvedValue(undefined) },
+    transport: { close: vi.fn().mockResolvedValue(undefined) },
+    transportType: 'streamable' as const,
+  };
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function seed(manager: any, ids: string[]) {
+  const runtimes = new Map<string, ReturnType<typeof fakeRuntime>>();
+  for (const id of ids) {
+    const rt = fakeRuntime();
+    runtimes.set(id, rt);
+    manager.runtimeSessions.set(id, rt);
+  }
+  return runtimes;
+}
+
+describe('selectOrphanedSessions', () => {
+  it('picks exactly the ids whose Redis record is gone', () => {
+    expect(selectOrphanedSessions(['a', 'b', 'c'], [1, 0, 1])).toEqual(['b']);
+  });
+
+  it('treats a non-zero reply as alive', () => {
+    expect(selectOrphanedSessions(['a', 'b'], [1, 1])).toEqual([]);
+  });
+
+  it('reaps nothing when every record is present', () => {
+    expect(selectOrphanedSessions(['a'], [1])).toEqual([]);
+  });
+});
+
+describe('SessionManager.sweepOrphanedSessions', () => {
+  beforeEach(() => {
+    pipelineExec.mockReset();
+    pipelineExists.mockReset();
+    redisDel.mockReset().mockResolvedValue(1);
+  });
+
+  it('is a no-op with nothing in memory', async () => {
+    const manager = new SessionManager();
+    await expect(manager.sweepOrphanedSessions()).resolves.toBe(0);
+    expect(pipelineExec).not.toHaveBeenCalled();
+  });
+
+  it('closes and drops only the sessions Redis has expired', async () => {
+    const manager = new SessionManager();
+    const runtimes = seed(manager, ['live', 'expired']);
+    pipelineExec.mockResolvedValue([
+      [null, 1],
+      [null, 0],
+    ]);
+
+    const reaped = await manager.sweepOrphanedSessions();
+
+    expect(reaped).toBe(1);
+    expect(manager.getActiveSessionIds()).toEqual(['live']);
+    expect(runtimes.get('expired')!.server.close).toHaveBeenCalled();
+    expect(runtimes.get('expired')!.transport.close).toHaveBeenCalled();
+    expect(runtimes.get('live')!.server.close).not.toHaveBeenCalled();
+  });
+
+  it('keeps every session when Redis errors, rather than reaping live ones', async () => {
+    // A transient Redis failure must never be read as "these sessions are gone".
+    const manager = new SessionManager();
+    seed(manager, ['a', 'b']);
+    pipelineExec.mockResolvedValue([
+      [new Error('READONLY'), null],
+      [new Error('READONLY'), null],
+    ]);
+
+    await expect(manager.sweepOrphanedSessions()).resolves.toBe(0);
+    expect(manager.getActiveSessionIds()).toEqual(['a', 'b']);
+  });
+
+  it('keeps sessions when the pipeline returns nothing at all', async () => {
+    const manager = new SessionManager();
+    seed(manager, ['a']);
+    pipelineExec.mockResolvedValue(null);
+
+    await expect(manager.sweepOrphanedSessions()).resolves.toBe(0);
+    expect(manager.getActiveSessionIds()).toEqual(['a']);
+  });
+
+  it('reclaims an accumulation of orphans in one pass', async () => {
+    // The production shape: many runtime sessions, few surviving Redis records.
+    const manager = new SessionManager();
+    const ids = Array.from({ length: 50 }, (_, i) => `s${i}`);
+    seed(manager, ids);
+    pipelineExec.mockResolvedValue(ids.map((_, i) => [null, i < 5 ? 1 : 0]));
+
+    await expect(manager.sweepOrphanedSessions()).resolves.toBe(45);
+    expect(manager.getActiveSessionIds()).toHaveLength(5);
+  });
+});
+
+describe('SessionManager idle sweep timer', () => {
+  beforeEach(() => {
+    pipelineExec.mockReset().mockResolvedValue([]);
+    pipelineExists.mockReset();
+  });
+
+  it('starts once and stops cleanly', () => {
+    vi.useFakeTimers();
+    const manager = new SessionManager();
+    const spy = vi.spyOn(manager, 'sweepOrphanedSessions').mockResolvedValue(0);
+
+    manager.startIdleSweep(1000);
+    manager.startIdleSweep(1000); // idempotent — must not add a second timer
+
+    vi.advanceTimersByTime(3000);
+    expect(spy).toHaveBeenCalledTimes(3);
+
+    manager.stopIdleSweep();
+    vi.advanceTimersByTime(5000);
+    expect(spy).toHaveBeenCalledTimes(3);
+
+    vi.useRealTimers();
+  });
+
+  it('survives a sweep that rejects', async () => {
+    vi.useFakeTimers();
+    const manager = new SessionManager();
+    vi.spyOn(manager, 'sweepOrphanedSessions').mockRejectedValue(new Error('boom'));
+    const logged = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    manager.startIdleSweep(1000);
+    vi.advanceTimersByTime(1000);
+    await Promise.resolve();
+
+    expect(logged).toHaveBeenCalled();
+    manager.stopIdleSweep();
+    vi.useRealTimers();
+    logged.mockRestore();
+  });
+});

--- a/src/http/session-manager.ts
+++ b/src/http/session-manager.ts
@@ -2,6 +2,7 @@ import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
 import { SSEServerTransport } from '@modelcontextprotocol/sdk/server/sse.js';
 import { getRedisClient } from './redis.js';
+import { SESSION_SWEEP_MS } from './config.js';
 import { registerInsforgeTools } from '../shared/tools/index.js';
 import { PACKAGE_VERSION } from '../shared/version.js';
 
@@ -44,9 +45,6 @@ const SESSION_KEY_PREFIX = 'mcp:session:';
 
 // Session TTL in seconds (24 hours)
 const SESSION_TTL = 24 * 60 * 60;
-
-// How often to reap runtime sessions whose Redis record is gone (5 minutes)
-const SWEEP_INTERVAL_MS = 5 * 60 * 1000;
 
 /**
  * Pick the runtime sessions that no longer have a Redis record.
@@ -338,7 +336,15 @@ export class SessionManager {
    * Returns how many were reaped.
    */
   async sweepOrphanedSessions(): Promise<number> {
-    const sessionIds = Array.from(this.runtimeSessions.keys());
+    // Streamable HTTP only. SSE has a real disconnect signal and cleans itself
+    // up on res 'close' — that asymmetry is the whole reason this reaper exists.
+    // Sweeping SSE too would close live connections: nothing on the SSE message
+    // path refreshes the record, so it lapses at SESSION_TTL from creation
+    // whether or not the client is active, and the keepalive means such a
+    // connection is still open when it does.
+    const sessionIds = Array.from(this.runtimeSessions.entries())
+      .filter(([, session]) => session.transportType === 'streamable')
+      .map(([sessionId]) => sessionId);
     if (sessionIds.length === 0) {
       return 0;
     }
@@ -375,7 +381,7 @@ export class SessionManager {
    * Start the periodic sweep. Idempotent; the timer is unref'd so it never
    * holds the process open on shutdown.
    */
-  startIdleSweep(intervalMs: number = SWEEP_INTERVAL_MS): void {
+  startIdleSweep(intervalMs: number = SESSION_SWEEP_MS): void {
     if (this.sweepTimer) {
       return;
     }

--- a/src/http/session-manager.ts
+++ b/src/http/session-manager.ts
@@ -42,6 +42,10 @@ interface RuntimeSession {
   // monotonic clock. Tracked in memory because it is the only record of
   // activity that survives Redis losing its data — see selectOrphanedSessions.
   lastSeenAt: number;
+  // Server->client streams currently open for this session (GET /mcp). A stream
+  // is activity that leaves no other trace: it produces no requests to stamp
+  // lastSeenAt and nothing that refreshes the Redis record.
+  openStreams: number;
 }
 
 // Redis key prefix
@@ -72,6 +76,7 @@ export function monotonicNow(): number {
 export interface SweepCandidate {
   sessionId: string;
   lastSeenAt: number;
+  openStreams: number;
 }
 
 /**
@@ -99,6 +104,12 @@ export interface SweepCandidate {
  * They diverge in exactly one case: Redis lost a record early. Then the
  * session we saw traffic on minutes ago is held, and one genuinely abandoned
  * is still collected on schedule.
+ *
+ * An open server->client stream counts as alive on its own. It is the one form
+ * of activity that stamps neither clock — the client holds GET /mcp open and
+ * may send no requests at all, so the record ages out and lastSeenAt stays
+ * frozen at the moment the stream opened. Both clocks then agree to reap a
+ * client that is plainly still connected.
  */
 export function selectOrphanedSessions(
   sessions: SweepCandidate[],
@@ -106,7 +117,30 @@ export function selectOrphanedSessions(
   now: number = monotonicNow()
 ): string[] {
   return sessions
-    .filter((session, i) => exists[i] === 0 && now - session.lastSeenAt >= SESSION_TTL_MS)
+    .filter(
+      (session, i) =>
+        exists[i] === 0 &&
+        session.openStreams === 0 &&
+        now - session.lastSeenAt >= SESSION_TTL_MS
+    )
+    .map((session) => session.sessionId);
+}
+
+/**
+ * Sessions whose Redis record vanished while they were still inside their TTL.
+ *
+ * That combination is evidence of Redis losing data rather than expiring it,
+ * and it is the only thing worth waking an operator for — the records are not
+ * coming back on their own. A session held only because a stream is open is
+ * NOT evidence of anything: its record expired on schedule, which is normal.
+ */
+export function selectPrematurelyMissing(
+  sessions: SweepCandidate[],
+  exists: number[],
+  now: number = monotonicNow()
+): string[] {
+  return sessions
+    .filter((session, i) => exists[i] === 0 && now - session.lastSeenAt < SESSION_TTL_MS)
     .map((session) => session.sessionId);
 }
 
@@ -172,7 +206,7 @@ export class SessionManager {
     );
 
     // Store runtime instances in memory
-    this.runtimeSessions.set(sessionId, { server, transport, transportType: 'streamable', lastSeenAt: monotonicNow() });
+    this.runtimeSessions.set(sessionId, { server, transport, transportType: 'streamable', lastSeenAt: monotonicNow(), openStreams: 0 });
 
     console.log(`[SessionManager] Session created: ${sessionId}`);
     return server;
@@ -274,7 +308,7 @@ export class SessionManager {
     await server.connect(transport);
 
     // Store runtime instances in memory
-    this.runtimeSessions.set(sessionId, { server, transport, transportType: 'streamable', lastSeenAt: monotonicNow() });
+    this.runtimeSessions.set(sessionId, { server, transport, transportType: 'streamable', lastSeenAt: monotonicNow(), openStreams: 0 });
 
     // Update last accessed time
     await this.touchSession(sessionId);
@@ -332,7 +366,7 @@ export class SessionManager {
     );
 
     // Store runtime instances in memory
-    this.runtimeSessions.set(sessionId, { server, transport, transportType: 'sse', lastSeenAt: monotonicNow() });
+    this.runtimeSessions.set(sessionId, { server, transport, transportType: 'sse', lastSeenAt: monotonicNow(), openStreams: 0 });
 
     console.log(`[SessionManager] SSE session created: ${sessionId}`);
     return server;
@@ -341,6 +375,38 @@ export class SessionManager {
   /**
    * Update last accessed time and refresh TTL
    */
+  /**
+   * Register a server->client stream as open, and stamp the session.
+   *
+   * Deliberately a count rather than a flag: a client may reconnect its stream
+   * before the old response has finished closing, and a flag cleared by the
+   * departing one would leave a live stream unprotected.
+   */
+  openStream(sessionId: string): void {
+    const runtime = this.runtimeSessions.get(sessionId);
+    if (!runtime) return;
+    runtime.openStreams += 1;
+    runtime.lastSeenAt = monotonicNow();
+  }
+
+  /**
+   * Release a stream. Safe to call for a session that has already been deleted,
+   * which happens whenever a close event lands after a reap or a DELETE.
+   */
+  closeStream(sessionId: string): void {
+    const runtime = this.runtimeSessions.get(sessionId);
+    if (!runtime) return;
+    runtime.openStreams = Math.max(0, runtime.openStreams - 1);
+    // The stream was alive right up to this moment; start the idle clock here
+    // rather than from whenever it opened.
+    runtime.lastSeenAt = monotonicNow();
+  }
+
+  /** Open stream count, for tests and diagnostics. */
+  getOpenStreamCount(sessionId: string): number {
+    return this.runtimeSessions.get(sessionId)?.openStreams ?? 0;
+  }
+
   async touchSession(sessionId: string): Promise<void> {
     const redis = getRedisClient();
 
@@ -401,7 +467,11 @@ export class SessionManager {
     // connection is still open when it does.
     const candidates: SweepCandidate[] = Array.from(this.runtimeSessions.entries())
       .filter(([, session]) => session.transportType === 'streamable')
-      .map(([sessionId, session]) => ({ sessionId, lastSeenAt: session.lastSeenAt }));
+      .map(([sessionId, session]) => ({
+        sessionId,
+        lastSeenAt: session.lastSeenAt,
+        openStreams: session.openStreams,
+      }));
     if (candidates.length === 0) {
       return 0;
     }
@@ -429,7 +499,7 @@ export class SessionManager {
     // Records gone while the session is still inside its TTL means Redis lost
     // data rather than expired it. Worth a line in the log: these sessions
     // survive the sweep but their records will not come back on their own.
-    const heldBack = exists.filter((e) => e === 0).length - orphaned.length;
+    const heldBack = selectPrematurelyMissing(candidates, exists).length;
     if (heldBack > 0) {
       console.warn(
         `[SessionManager] ${heldBack} session(s) lost their Redis record before TTL — holding them; check Redis for a restart, failover or eviction`

--- a/src/http/session-manager.ts
+++ b/src/http/session-manager.ts
@@ -45,6 +45,25 @@ const SESSION_KEY_PREFIX = 'mcp:session:';
 // Session TTL in seconds (24 hours)
 const SESSION_TTL = 24 * 60 * 60;
 
+// How often to reap runtime sessions whose Redis record is gone (5 minutes)
+const SWEEP_INTERVAL_MS = 5 * 60 * 1000;
+
+/**
+ * Pick the runtime sessions that no longer have a Redis record.
+ *
+ * Redis owns session lifetime — the record expires on SESSION_TTL — but the
+ * in-memory McpServer and transport are only dropped on an explicit DELETE.
+ * Streamable HTTP clients mostly never send one, so anything whose record has
+ * gone is an orphan holding a server, a transport and a full tool registry.
+ *
+ * `exists` is the pipelined EXISTS reply for the matching id. A missing or
+ * failed reply counts as alive: a transient Redis error must never be read as
+ * "reap this live session".
+ */
+export function selectOrphanedSessions(sessionIds: string[], exists: number[]): string[] {
+  return sessionIds.filter((_, i) => exists[i] === 0);
+}
+
 /**
  * SessionManager handles MCP session lifecycle with Redis persistence
  *
@@ -55,6 +74,9 @@ const SESSION_TTL = 24 * 60 * 60;
 export class SessionManager {
   // In-memory cache for runtime instances
   private runtimeSessions = new Map<string, RuntimeSession>();
+
+  // Periodic reaper for runtime sessions Redis has already expired
+  private sweepTimer?: NodeJS.Timeout;
 
   /**
    * Create a new session
@@ -309,6 +331,70 @@ export class SessionManager {
     await redis.del(SESSION_KEY_PREFIX + sessionId);
 
     console.log(`[SessionManager] Session deleted: ${sessionId}`);
+  }
+
+  /**
+   * Drop runtime sessions whose Redis record has gone, closing each one.
+   * Returns how many were reaped.
+   */
+  async sweepOrphanedSessions(): Promise<number> {
+    const sessionIds = Array.from(this.runtimeSessions.keys());
+    if (sessionIds.length === 0) {
+      return 0;
+    }
+
+    const redis = getRedisClient();
+    const pipeline = redis.pipeline();
+    for (const sessionId of sessionIds) {
+      pipeline.exists(SESSION_KEY_PREFIX + sessionId);
+    }
+    const replies = await pipeline.exec();
+
+    // A failed or absent reply is treated as "still alive" so a Redis blip
+    // can't take out live sessions.
+    const exists = sessionIds.map((_, i) => {
+      const reply = replies?.[i];
+      if (!reply || reply[0]) return 1;
+      return Number(reply[1]);
+    });
+
+    const orphaned = selectOrphanedSessions(sessionIds, exists);
+    for (const sessionId of orphaned) {
+      await this.deleteSession(sessionId);
+    }
+
+    if (orphaned.length > 0) {
+      console.log(
+        `[SessionManager] Swept ${orphaned.length} orphaned session(s); ${this.runtimeSessions.size} remain in memory`
+      );
+    }
+    return orphaned.length;
+  }
+
+  /**
+   * Start the periodic sweep. Idempotent; the timer is unref'd so it never
+   * holds the process open on shutdown.
+   */
+  startIdleSweep(intervalMs: number = SWEEP_INTERVAL_MS): void {
+    if (this.sweepTimer) {
+      return;
+    }
+    this.sweepTimer = setInterval(() => {
+      this.sweepOrphanedSessions().catch((error) => {
+        console.error('[SessionManager] Sweep failed:', error);
+      });
+    }, intervalMs);
+    this.sweepTimer.unref();
+  }
+
+  /**
+   * Stop the periodic sweep.
+   */
+  stopIdleSweep(): void {
+    if (this.sweepTimer) {
+      clearInterval(this.sweepTimer);
+      this.sweepTimer = undefined;
+    }
   }
 
   /**

--- a/src/http/session-manager.ts
+++ b/src/http/session-manager.ts
@@ -38,6 +38,10 @@ interface RuntimeSession {
   server: McpServer;
   transport: StreamableHTTPServerTransport | SSEServerTransport;
   transportType: 'streamable' | 'sse';
+  // Last time this process saw real client traffic for the session, on the
+  // monotonic clock. Tracked in memory because it is the only record of
+  // activity that survives Redis losing its data — see selectOrphanedSessions.
+  lastSeenAt: number;
 }
 
 // Redis key prefix
@@ -45,6 +49,30 @@ const SESSION_KEY_PREFIX = 'mcp:session:';
 
 // Session TTL in seconds (24 hours)
 const SESSION_TTL = 24 * 60 * 60;
+
+// Session TTL in milliseconds, for comparison against in-memory timestamps.
+export const SESSION_TTL_MS = SESSION_TTL * 1000;
+
+/**
+ * Clock for in-memory session ages.
+ *
+ * Deliberately monotonic rather than Date.now(). These timestamps are only
+ * ever compared against each other to measure elapsed time, never against
+ * anything Redis stores, so wall-clock accuracy buys nothing — while a
+ * forward clock step (NTP correction, a VM resuming from suspend) would age
+ * every live session past its TTL at once and hand the sweep the exact
+ * conclusion this gate exists to prevent. CLOCK_MONOTONIC can only lag real
+ * elapsed time, which errs toward holding a session too long.
+ */
+export function monotonicNow(): number {
+  return performance.now();
+}
+
+/** The sweep's view of one runtime session. */
+export interface SweepCandidate {
+  sessionId: string;
+  lastSeenAt: number;
+}
 
 /**
  * Pick the runtime sessions that no longer have a Redis record.
@@ -57,9 +85,29 @@ const SESSION_TTL = 24 * 60 * 60;
  * `exists` is the pipelined EXISTS reply for the matching id. A missing or
  * failed reply counts as alive: a transient Redis error must never be read as
  * "reap this live session".
+ *
+ * A missing record is necessary but not sufficient. Redis can also come back
+ * empty — a restart without persistence, a failover to a cold replica, an
+ * eviction — and then every resident session reads as an orphan at once, so
+ * the sweep would close connections that are actively serving traffic.
+ * touchSession cannot repair that: it only rewrites a record it can still
+ * read, so a wiped record stays wiped no matter how busy the client is.
+ *
+ * The in-memory clock settles it. A record only expires SESSION_TTL after the
+ * last touch, and that same touch stamps lastSeenAt, so the two cross at the
+ * same instant during normal operation and this gate costs no reap latency.
+ * They diverge in exactly one case: Redis lost a record early. Then the
+ * session we saw traffic on minutes ago is held, and one genuinely abandoned
+ * is still collected on schedule.
  */
-export function selectOrphanedSessions(sessionIds: string[], exists: number[]): string[] {
-  return sessionIds.filter((_, i) => exists[i] === 0);
+export function selectOrphanedSessions(
+  sessions: SweepCandidate[],
+  exists: number[],
+  now: number = monotonicNow()
+): string[] {
+  return sessions
+    .filter((session, i) => exists[i] === 0 && now - session.lastSeenAt >= SESSION_TTL_MS)
+    .map((session) => session.sessionId);
 }
 
 /**
@@ -124,7 +172,7 @@ export class SessionManager {
     );
 
     // Store runtime instances in memory
-    this.runtimeSessions.set(sessionId, { server, transport, transportType: 'streamable' });
+    this.runtimeSessions.set(sessionId, { server, transport, transportType: 'streamable', lastSeenAt: monotonicNow() });
 
     console.log(`[SessionManager] Session created: ${sessionId}`);
     return server;
@@ -226,7 +274,7 @@ export class SessionManager {
     await server.connect(transport);
 
     // Store runtime instances in memory
-    this.runtimeSessions.set(sessionId, { server, transport, transportType: 'streamable' });
+    this.runtimeSessions.set(sessionId, { server, transport, transportType: 'streamable', lastSeenAt: monotonicNow() });
 
     // Update last accessed time
     await this.touchSession(sessionId);
@@ -284,7 +332,7 @@ export class SessionManager {
     );
 
     // Store runtime instances in memory
-    this.runtimeSessions.set(sessionId, { server, transport, transportType: 'sse' });
+    this.runtimeSessions.set(sessionId, { server, transport, transportType: 'sse', lastSeenAt: monotonicNow() });
 
     console.log(`[SessionManager] SSE session created: ${sessionId}`);
     return server;
@@ -295,6 +343,15 @@ export class SessionManager {
    */
   async touchSession(sessionId: string): Promise<void> {
     const redis = getRedisClient();
+
+    // Stamp memory first and unconditionally. The Redis write below is a
+    // no-op when the record is already gone, so this is the only evidence of
+    // activity that outlives Redis losing its data.
+    const runtime = this.runtimeSessions.get(sessionId);
+    if (runtime) {
+      runtime.lastSeenAt = monotonicNow();
+    }
+
     const sessionData = await this.getSessionData(sessionId);
 
     if (sessionData) {
@@ -342,31 +399,41 @@ export class SessionManager {
     // path refreshes the record, so it lapses at SESSION_TTL from creation
     // whether or not the client is active, and the keepalive means such a
     // connection is still open when it does.
-    const sessionIds = Array.from(this.runtimeSessions.entries())
+    const candidates: SweepCandidate[] = Array.from(this.runtimeSessions.entries())
       .filter(([, session]) => session.transportType === 'streamable')
-      .map(([sessionId]) => sessionId);
-    if (sessionIds.length === 0) {
+      .map(([sessionId, session]) => ({ sessionId, lastSeenAt: session.lastSeenAt }));
+    if (candidates.length === 0) {
       return 0;
     }
 
     const redis = getRedisClient();
     const pipeline = redis.pipeline();
-    for (const sessionId of sessionIds) {
+    for (const { sessionId } of candidates) {
       pipeline.exists(SESSION_KEY_PREFIX + sessionId);
     }
     const replies = await pipeline.exec();
 
     // A failed or absent reply is treated as "still alive" so a Redis blip
     // can't take out live sessions.
-    const exists = sessionIds.map((_, i) => {
+    const exists = candidates.map((_, i) => {
       const reply = replies?.[i];
       if (!reply || reply[0]) return 1;
       return Number(reply[1]);
     });
 
-    const orphaned = selectOrphanedSessions(sessionIds, exists);
+    const orphaned = selectOrphanedSessions(candidates, exists);
     for (const sessionId of orphaned) {
       await this.deleteSession(sessionId);
+    }
+
+    // Records gone while the session is still inside its TTL means Redis lost
+    // data rather than expired it. Worth a line in the log: these sessions
+    // survive the sweep but their records will not come back on their own.
+    const heldBack = exists.filter((e) => e === 0).length - orphaned.length;
+    if (heldBack > 0) {
+      console.warn(
+        `[SessionManager] ${heldBack} session(s) lost their Redis record before TTL — holding them; check Redis for a restart, failover or eviction`
+      );
     }
 
     if (orphaned.length > 0) {

--- a/src/http/session-manager.ts
+++ b/src/http/session-manager.ts
@@ -488,12 +488,32 @@ export class SessionManager {
     const exists = candidates.map((_, i) => {
       const reply = replies?.[i];
       if (!reply || reply[0]) return 1;
-      return Number(reply[1]);
+      const value = reply[1];
+      // EXISTS answers with an integer. Anything else — null in particular —
+      // is not a statement that the key is absent, and Number(null) is 0, so a
+      // bare cast turns an indeterminate reply into "reap this". Alive unless
+      // Redis actually said zero.
+      if (typeof value !== 'number' && typeof value !== 'string') return 1;
+      const count = Number(value);
+      return Number.isInteger(count) ? count : 1;
     });
 
-    const orphaned = selectOrphanedSessions(candidates, exists);
-    for (const sessionId of orphaned) {
+    const selected = selectOrphanedSessions(candidates, exists);
+
+    // Re-check each one against the live entry immediately before closing it.
+    // The candidate list is a snapshot taken before the EXISTS round trip, and
+    // a request can arrive in that window: touchSession stamps lastSeenAt and
+    // rewrites the record, so acting on the snapshot would close a session that
+    // just proved it is alive.
+    const orphaned: string[] = [];
+    for (const sessionId of selected) {
+      const current = this.runtimeSessions.get(sessionId);
+      if (!current) continue;
+      if (current.openStreams > 0 || monotonicNow() - current.lastSeenAt < SESSION_TTL_MS) {
+        continue;
+      }
       await this.deleteSession(sessionId);
+      orphaned.push(sessionId);
     }
 
     // Records gone while the session is still inside its TTL means Redis lost


### PR DESCRIPTION
Fixes the memory growth behind `/health` reporting **510 active sessions against 4443 held in memory** on the deployed box — the 4GB instance that also serves customer Postgres. Assigned out of the port thread; deliberately **not** folded into PR2, because PR2 is gated on the deploy question and this shouldn't wait for an engine swap.

## 1. Session leak (the OOM risk)

Redis owns session lifetime via `SESSION_TTL`, but the in-memory `McpServer` + transport are only dropped on an explicit `DELETE /mcp`.

- SSE cleans up properly on `res.on('close')`.
- **Streamable HTTP has no equivalent signal**, and clients rarely send `DELETE`. So every session created since process start stays resident, each holding a server, a transport, and a full 17-tool registry. There was no sweeper and no idle eviction — `deleteSession` was reachable only from `DELETE /mcp`, the SSE close handler, and shutdown.

That is exactly the observed shape: Redis expires records on TTL, memory never does, so `memorySessionCount` climbs away from `activeSessions`.

**Fix:** Redis is already the source of truth, so read from it. Every 5 minutes, pipeline `EXISTS` across the resident session ids and close the ones whose record has gone. A failed *or absent* reply counts as **alive**, so a transient Redis error can never be read as "reap these live sessions". Timer is `unref()`'d and stopped on shutdown.

## 2. SSE keepalive

An idle SSE stream carries no bytes, so the load balancer closes it on its idle timeout (60s by default on an ALB) and the client sees a dropped connection. There was no keepalive of any kind. Now a comment frame every 25s — ignored by the event-stream parser and by the transport's own framing, so it's invisible to clients.

## Verification

Against a **real Redis**, using the built server:

```
session created                    → {activeSessions: 1, memorySessionCount: 1}
record expires, no DELETE sent     → {activeSessions: 0, memorySessionCount: 1}   ← the production signature, reproduced
after one sweep                    → {activeSessions: 0, memorySessionCount: 0}
[SessionManager] Swept 1 orphaned session(s); 0 remain in memory
```

Idle `/sse` stream over 4s emits `: keepalive` frames as expected.

28/28 vitest (10 new), `tsc` and `eslint` clean, build succeeds. The sweep tests cover the cases that matter: only-expired-are-reaped, Redis errors reap nothing, an empty pipeline reply reaps nothing, 45-of-50 orphans reclaimed in one pass, and the timer being idempotent, stoppable and rejection-safe.

## Blast radius

The running HTTP server. The sweep only closes **streamable** sessions Redis has already expired; SSE is left alone, since it has its own disconnect signal and cleans up on `res` `close`. (An earlier version of this note claimed such a client would be rejected on its next request anyway — that was wrong: `getStreamableSession` reads memory first, so it would have been served without consulting Redis. Corrected after review.) Both intervals take an env override (`MCP_SESSION_SWEEP_MS`, `MCP_SSE_KEEPALIVE_MS`) so they can be tuned to an environment's LB timeout without a redeploy of code.

## Note on deploying it

Per the thread, `mcp.insforge.dev` is 139 days stale, has no deploy path, and shares an instance with customer Postgres on 5432. **This PR doesn't change when it's safe to deploy** — it just means the leak is fixed whenever that question is resolved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the runtime session leak, keeps SSE connections alive behind ALBs, and adds memory stats to `/health`. The reaper now gates on in‑memory activity, ignores Redis wipes, re‑checks before closing, and never closes sessions while a stream is open.

- **Bug Fixes**
  - Session reaper (streamable only): runs every 5m; pipelines `EXISTS`; error/empty/non‑integer replies count as alive; reaps only when the Redis record is missing AND in‑memory `lastSeenAt` is past TTL AND there are no open streams; re‑checks the live entry before closing; warns when records vanish inside TTL; timer is unref’d and stopped on shutdown. Tracks stream open/close on `GET /mcp`, touches on open to restart TTL, and resets the idle clock on close.
  - SSE: writes a “: keepalive” comment every 25s and clears on close; refreshes session TTL on `POST /messages` so active SSE sessions don’t expire; never swept by the reaper.
  - Config: intervals tunable via `MCP_SESSION_SWEEP_MS` and `MCP_SSE_KEEPALIVE_MS`; overrides must be positive integers; invalid values fall back to defaults.

- **New Features**
  - `/health` now reports `heapUsedMb`, `heapLimitMb`, `heapUsedPct`, and `rssMb`.

<sup>Written for commit a1b7abe0a5ddf92533e3e252daaada41be905229. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/insforge-mcp/pull/71?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable legacy SSE keep-alives and startup/shutdown idle session sweeping via environment-driven timing constants.
  * Enhanced the health endpoint with heap/memory metrics.
* **Bug Fixes**
  * Implemented TTL-gated orphan reaping for streamable runtime sessions when Redis records disappear, without affecting active SSE sessions.
  * Refreshes session activity on message arrival in a non-blocking manner.
* **Tests**
  * Added Vitest coverage for env parsing, SSE keepalive behavior, and session reaping/idle sweep timer controls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->