### PR TITLE
fix(redis): actually send the password, and accept a REDIS_URL

### DIFF
--- a/src/http/config.ts
+++ b/src/http/config.ts
@@ -76,23 +76,11 @@ export const OAUTH_CONFIG = {
 // ============================================================================
 // Redis Configuration
 // ============================================================================
-
-export const REDIS_CONFIG = {
-  /** Redis host */
-  host: process.env.REDIS_HOST || 'localhost',
-
-  /** Redis port */
-  port: parseInt(process.env.REDIS_PORT || '6379'),
-
-  /** Redis password */
-  password: process.env.REDIS_PASSWORD || undefined,
-
-  /** Use TLS for Redis connection */
-  tls: process.env.REDIS_TLS === 'true',
-
-  /** Use Redis cluster mode */
-  cluster: process.env.REDIS_CLUSTER === 'true',
-} as const;
+//
+// Deliberately not here. Redis config is read in redis.ts, next to the client
+// it configures. A second copy lived here, unimported, and it advertised a
+// REDIS_PASSWORD that the real client never sent — so a password-protected
+// Redis failed to connect with the variable sitting there looking correct.
 
 // ============================================================================
 // Session Configuration

--- a/src/http/redis.test.ts
+++ b/src/http/redis.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect } from 'vitest';
+import { resolveRedisClientSpec, type RedisConfig } from './redis.js';
+
+/**
+ * These exist because of a bug that was invisible: REDIS_PASSWORD was read into
+ * a config object nothing imported, while the real client built its own options
+ * and never sent a password. Every managed Redis requires AUTH, so the server
+ * could not connect to one — and the env var sat there looking correct.
+ *
+ * The assertions are on the resolved spec rather than a live client, so they
+ * check what ioredis is actually handed without opening a socket.
+ */
+
+const base: RedisConfig = {
+  host: 'redis.internal',
+  port: 6379,
+  tls: false,
+  cluster: false,
+};
+
+describe('resolveRedisClientSpec — standalone', () => {
+  it('passes the password through to ioredis', () => {
+    const spec = resolveRedisClientSpec({ ...base, password: 's3cret' });
+    expect(spec.kind).toBe('standalone');
+    expect(spec.options.password).toBe('s3cret');
+  });
+
+  it('passes a username through for ACL-style auth', () => {
+    const spec = resolveRedisClientSpec({ ...base, username: 'app', password: 's3cret' });
+    expect(spec.options.username).toBe('app');
+    expect(spec.options.password).toBe('s3cret');
+  });
+
+  it('omits credentials entirely when none are configured', () => {
+    const spec = resolveRedisClientSpec(base);
+    expect(spec.options).not.toHaveProperty('password');
+    expect(spec.options).not.toHaveProperty('username');
+  });
+
+  it('keeps host, port and the retry policy', () => {
+    const spec = resolveRedisClientSpec(base);
+    expect(spec.options.host).toBe('redis.internal');
+    expect(spec.options.port).toBe(6379);
+    expect(spec.options.maxRetriesPerRequest).toBe(3);
+  });
+
+  it('enables TLS when asked', () => {
+    expect(resolveRedisClientSpec({ ...base, tls: true }).options.tls).toEqual({});
+    expect(resolveRedisClientSpec(base).options).not.toHaveProperty('tls');
+  });
+});
+
+describe('resolveRedisClientSpec — URL', () => {
+  // The shape managed Redis is normally handed over in: one variable with the
+  // credentials already embedded.
+  it('is used verbatim so ioredis can parse credentials out of it', () => {
+    const spec = resolveRedisClientSpec({
+      ...base,
+      url: 'redis://app:s3cret@redis.example:6380',
+    });
+    expect(spec).toMatchObject({ kind: 'url', url: 'redis://app:s3cret@redis.example:6380' });
+  });
+
+  it('carries the retry policy alongside the URL', () => {
+    const spec = resolveRedisClientSpec({ ...base, url: 'rediss://redis.example:6380' });
+    expect(spec.options.maxRetriesPerRequest).toBe(3);
+  });
+
+  it('takes precedence over the discrete host and port', () => {
+    const spec = resolveRedisClientSpec({
+      ...base,
+      host: 'ignored.example',
+      url: 'redis://redis.example:6380',
+    });
+    expect(spec.kind).toBe('url');
+    expect(spec.options).not.toHaveProperty('host');
+  });
+
+  it('does not hijack cluster mode', () => {
+    // Cluster is configured by node list, not by URL — a URL alongside it must
+    // not silently downgrade the client to standalone.
+    const spec = resolveRedisClientSpec({ ...base, cluster: true, url: 'redis://x:6379' });
+    expect(spec.kind).toBe('cluster');
+  });
+});
+
+describe('resolveRedisClientSpec — cluster', () => {
+  it('sends credentials via redisOptions, where the cluster client reads them', () => {
+    const spec = resolveRedisClientSpec({
+      ...base,
+      cluster: true,
+      username: 'app',
+      password: 's3cret',
+    });
+    expect(spec.kind).toBe('cluster');
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const redisOptions = (spec.options as any).redisOptions;
+    expect(redisOptions.password).toBe('s3cret');
+    expect(redisOptions.username).toBe('app');
+  });
+
+  it('still targets the configured node and enables TLS', () => {
+    const spec = resolveRedisClientSpec({ ...base, cluster: true, tls: true });
+    expect(spec).toMatchObject({ nodes: [{ host: 'redis.internal', port: 6379 }] });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((spec.options as any).redisOptions.tls).toEqual({});
+  });
+});

--- a/src/http/redis.ts
+++ b/src/http/redis.ts
@@ -1,59 +1,108 @@
-import Redis, { Cluster } from 'ioredis';
+import Redis, { Cluster, type RedisOptions } from 'ioredis';
 
 export interface RedisConfig {
+  /**
+   * Full connection URL, e.g. redis://user:pass@host:6379 or rediss://…
+   * Managed Redis is usually handed over this way with credentials embedded,
+   * so when it's set it wins over the discrete fields.
+   */
+  url?: string;
   host: string;
   port: number;
+  username?: string;
+  password?: string;
   tls: boolean;
   cluster: boolean;
 }
+
+/**
+ * How the client will be built, kept as data so it can be asserted without
+ * opening a socket. The bug this replaced was a password that looked
+ * configured and never reached ioredis, which no test could have caught while
+ * the options were built inline.
+ */
+export type RedisClientSpec =
+  | { kind: 'url'; url: string; options: RedisOptions }
+  | { kind: 'standalone'; options: RedisOptions }
+  | { kind: 'cluster'; nodes: Array<{ host: string; port: number }>; options: RedisOptions };
+
+const BASE_OPTIONS: RedisOptions = {
+  maxRetriesPerRequest: 3,
+  retryStrategy(times: number) {
+    return Math.min(times * 100, 3000);
+  },
+};
 
 /**
  * Get Redis configuration from environment variables
  */
 export function getRedisConfig(): RedisConfig {
   return {
+    url: process.env.REDIS_URL || undefined,
     host: process.env.REDIS_HOST || 'localhost',
     port: parseInt(process.env.REDIS_PORT || '6379', 10),
+    username: process.env.REDIS_USERNAME || undefined,
+    password: process.env.REDIS_PASSWORD || undefined,
     tls: process.env.REDIS_TLS === 'true',
     cluster: process.env.REDIS_CLUSTER === 'true',
   };
 }
 
 /**
- * Create a Redis client based on configuration
- * Supports both standalone and cluster mode with optional TLS
+ * Resolve a config into the exact shape ioredis is constructed with.
  */
-export function createRedisClient(config?: RedisConfig): Redis | Cluster {
-  const redisConfig = config || getRedisConfig();
-  const { host, port, tls, cluster } = redisConfig;
+export function resolveRedisClientSpec(config: RedisConfig): RedisClientSpec {
+  const { url, host, port, username, password, tls, cluster } = config;
 
-  const tlsOptions = tls ? { tls: {} } : {};
+  const credentials: RedisOptions = {
+    ...(username ? { username } : {}),
+    ...(password ? { password } : {}),
+  };
+  // A rediss:// URL already implies TLS; only the discrete flag needs translating.
+  const tlsOptions: RedisOptions = tls ? { tls: {} } : {};
 
   if (cluster) {
-    // Cluster mode (for AWS ElastiCache Serverless, etc.)
-    return new Redis.Cluster(
-      [{ host, port }],
-      {
-        redisOptions: {
-          ...tlsOptions,
-        },
-        dnsLookup: (address, callback) => callback(null, address),
+    // Cluster mode (AWS ElastiCache Serverless, etc.)
+    return {
+      kind: 'cluster',
+      nodes: [{ host, port }],
+      options: {
+        redisOptions: { ...credentials, ...tlsOptions },
+        dnsLookup: (address: string, callback: (err: null, addr: string) => void) =>
+          callback(null, address),
         slotsRefreshTimeout: 2000,
         enableReadyCheck: true,
-      }
-    );
-  } else {
-    // Standalone mode (local development)
-    return new Redis({
-      host,
-      port,
-      ...tlsOptions,
-      maxRetriesPerRequest: 3,
-      retryStrategy(times) {
-        const delay = Math.min(times * 100, 3000);
-        return delay;
-      },
-    });
+      } as RedisOptions,
+    };
+  }
+
+  if (url) {
+    // ioredis parses username, password, host, port and the rediss:// TLS
+    // switch straight out of the URL.
+    return { kind: 'url', url, options: { ...BASE_OPTIONS } };
+  }
+
+  return {
+    kind: 'standalone',
+    options: { host, port, ...credentials, ...tlsOptions, ...BASE_OPTIONS },
+  };
+}
+
+/**
+ * Create a Redis client based on configuration
+ * Supports a connection URL, standalone and cluster mode, with optional TLS.
+ */
+export function createRedisClient(config?: RedisConfig): Redis | Cluster {
+  const spec = resolveRedisClientSpec(config || getRedisConfig());
+
+  switch (spec.kind) {
+    case 'cluster':
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      return new Redis.Cluster(spec.nodes, spec.options as any);
+    case 'url':
+      return new Redis(spec.url, spec.options);
+    default:
+      return new Redis(spec.options);
   }
 }
 


### PR DESCRIPTION
Blocks the trial deploy right now. Found by @Iris while diagnosing the crash; handed to me rather than cutting across #71's branch.

## The bug

`REDIS_PASSWORD` was read into a `REDIS_CONFIG` object in `config.ts` **that nothing imported** — one reference in the whole repo, its own definition. The real client in `redis.ts` built its own options from `{host, port, tls, cluster}` and never passed a password to ioredis.

So the server cannot connect to any Redis that requires AUTH, while the environment variable sits there looking correct. Nearly every managed Redis is password-protected, so this blocks running anywhere except our own ElastiCache — which authorises by security group rather than AUTH, which is why it has never bitten us.

Measured against a password-protected Redis with `REDIS_PASSWORD` correctly set:

```
master:    [Redis] Connection error: NOAUTH Authentication required.
           Failed to start server: ReplyError: NOAUTH Authentication required.
           exit code 1                       ← indistinguishable from "no Redis at all"
this PR:   /health → ok
```

## What changed

- **Password and username are threaded through** for standalone and cluster (cluster takes them via `redisOptions`).
- **`REDIS_URL` is supported** — the shape managed Redis is normally handed over in: one variable with credentials embedded rather than five. ioredis parses user, password, host, port and the `rediss://` TLS switch out of it. A URL wins over the discrete fields, but does **not** override cluster mode, which is configured by node list.
- **The duplicate config is deleted, not fixed.** A second unimported copy of the Redis settings is exactly what made a missing feature look like a present one. `redis.ts` is now the single place Redis config is read, next to the client it configures.
- **Options are built in `resolveRedisClientSpec`**, so what ioredis is handed can be asserted without opening a socket. The previous inline shape couldn't be tested at all, which is why a password that never arrived went unnoticed.

## Verification

11 new tests covering: password reaches ioredis, username for ACL auth, credentials omitted when unset, TLS on/off, URL used verbatim, URL beating discrete fields, URL *not* hijacking cluster mode, and cluster credentials landing in `redisOptions`.

End-to-end against a real password-protected Redis (`redis-server --requirepass`): `master` exits 1 with `NOAUTH`; this branch serves `/health` both via `REDIS_PASSWORD` and via a single `REDIS_URL`.

29/29 suite, `tsc` and `eslint` clean.

## Blast radius

Redis connection setup — every deployment. Behaviour with our current env is unchanged: no `REDIS_URL`, no `REDIS_PASSWORD`, `REDIS_CLUSTER=true` resolves to the same cluster client with the same node, TLS and timeouts as before. The change only adds paths that previously didn't work.

Worth knowing for the trial: `REDIS_CLUSTER=true` is right for our ElastiCache and wrong for a single-node platform Redis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix Redis auth by sending credentials to `ioredis` and adding `REDIS_URL` support. Removes the unused config so managed Redis works and trial deploys are unblocked.

- **Bug Fixes**
  - Thread `username`/`password` through for standalone and cluster (via `redisOptions`); TLS still supported.
  - Remove the unused Redis config in `src/http/config.ts` that read `REDIS_PASSWORD` but was never used.

- **New Features**
  - Support `REDIS_URL` (e.g., `rediss://user:pass@host:port`), parsed by `ioredis`.
  - URL takes precedence over discrete host/port/TLS, but does not override cluster mode.

<sup>Written for commit 69a03a3f0bd9da3229b5ffaebef53b1c2b2491bf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/insforge-mcp/pull/72?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring Redis connections with a full URL and optional username/password credentials.
  * Improved TLS and cluster connection configuration.

* **Bug Fixes**
  * Corrected credential handling for standalone and clustered Redis connections.
  * Preserved retry settings across supported connection modes.
  * Ensured URL-based configuration takes precedence where applicable.

* **Tests**
  * Added comprehensive coverage for standalone, URL, TLS, credential, and cluster connection scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->