### PR TITLE
Stop client registrations expiring while they are in use

### DIFF
--- a/src/http/server.ts
+++ b/src/http/server.ts
@@ -23,6 +23,7 @@ import {
   validateConfig,
 } from './config.js';
 import { renderProjectSelectionPage } from './templates/project-selection.js';
+import { renderOAuthErrorPage } from './templates/oauth-error.js';
 import { getAnalyticsService, extractClientInfo } from './analytics.js';
 import { PACKAGE_VERSION } from '../shared/version.js';
 
@@ -77,6 +78,28 @@ function isInitializeRequest(body: unknown): boolean {
   }
 
   return false;
+}
+
+/**
+ * How long a client registration survives without being used.
+ *
+ * Refreshed on every successful authorize (see below), so this is an idle
+ * timeout rather than a hard lifetime. It used to be neither: the value was
+ * written once at registration and never touched again, so every client
+ * stopped working exactly 30 days after it registered no matter how heavily
+ * it was being used.
+ */
+const CLIENT_REGISTRATION_TTL = 30 * 24 * 60 * 60;
+
+/**
+ * Whether this request is a browser navigation rather than a program's fetch.
+ *
+ * The authorize endpoint is reached by opening a URL in the user's browser —
+ * the MCP client never reads the response itself — so an error here has to be
+ * written for a person. Everything else still gets the OAuth JSON body.
+ */
+function prefersHtml(req: Request): boolean {
+  return req.accepts(['json', 'html']) === 'html';
 }
 
 /**
@@ -217,7 +240,7 @@ app.post(OAUTH_ENDPOINTS.register, async (req: Request, res: Response) => {
 
   await redis.setex(
     `mcp:oauth:client:${clientId}`,
-    30 * 24 * 60 * 60,
+    CLIENT_REGISTRATION_TTL,
     JSON.stringify(clientData)
   );
 
@@ -267,8 +290,26 @@ app.get(OAUTH_ENDPOINTS.authorize, async (req: Request, res: Response) => {
 
   // Validate client_id and redirect_uri
   const redis = getRedisClient();
-  const clientDataStr = await redis.get(`mcp:oauth:client:${client_id}`);
+  const clientKey = `mcp:oauth:client:${client_id}`;
+  const clientDataStr = await redis.get(clientKey);
   if (!clientDataStr) {
+    // Nothing here can recover automatically. The MCP SDK only re-registers on
+    // an invalid_client from the token endpoint or from registration, and it
+    // never sees this response — the browser does. So the person holding the
+    // tab is the only one who can act, and they need to be told how.
+    console.log(`[OAuth] Unknown client_id at authorize: ${client_id}`);
+    if (prefersHtml(req)) {
+      return res.status(400).type('html').send(
+        renderOAuthErrorPage({
+          heading: 'This connection needs to be set up again',
+          message:
+            'The app you are connecting from is not registered with this server any more. ' +
+            'Nothing is wrong with your account and no data was lost — remove the InsForge MCP ' +
+            'server from your client and add it back, and this will complete normally.',
+          action: 'npx @insforge/install',
+        })
+      );
+    }
     return res.status(400).json({
       error: 'invalid_client',
       error_description: 'Unknown client_id. Register client first via /oauth/register.',
@@ -309,6 +350,16 @@ app.get(OAUTH_ENDPOINTS.authorize, async (req: Request, res: Response) => {
       error: 'invalid_request',
       error_description: 'redirect_uri does not match any registered redirect URIs for this client.',
     });
+  }
+
+  // The registration has been used successfully, so restart its idle clock.
+  // Without this the record expires on a fixed schedule from the moment it was
+  // written, taking working clients down with it. Failing to refresh must not
+  // fail the login — the worst case is the record expiring on its old schedule.
+  try {
+    await redis.expire(clientKey, CLIENT_REGISTRATION_TTL);
+  } catch (error) {
+    console.error(`[OAuth] Could not refresh registration TTL for ${client_id}:`, error);
   }
 
   try {

--- a/src/http/templates/oauth-error.test.ts
+++ b/src/http/templates/oauth-error.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest';
+import { renderOAuthErrorPage } from './oauth-error.js';
+
+describe('renderOAuthErrorPage', () => {
+  it('renders the heading, message and action', () => {
+    const html = renderOAuthErrorPage({
+      heading: 'Set this up again',
+      message: 'The app is not registered any more.',
+      action: 'npx @insforge/install',
+    });
+
+    expect(html).toContain('<h1>Set this up again</h1>');
+    expect(html).toContain('The app is not registered any more.');
+    expect(html).toContain('<code>npx @insforge/install</code>');
+    expect(html.startsWith('<!DOCTYPE html>')).toBe(true);
+  });
+
+  it('omits the code block when there is no action', () => {
+    const html = renderOAuthErrorPage({ heading: 'Nope', message: 'No action here.' });
+    expect(html).not.toContain('<code>');
+  });
+
+  it('escapes every field, so a reflected value cannot become markup', () => {
+    // Nothing untrusted is passed today, but this page sits on an unauthenticated
+    // endpoint reached straight from a URL — the escaping is what keeps it safe
+    // if someone later renders the client_id or redirect_uri into it.
+    const html = renderOAuthErrorPage({
+      heading: '<script>alert(1)</script>',
+      message: '"quoted" & <b>bold</b>',
+      action: "';DROP--<img src=x onerror=alert(1)>",
+    });
+
+    expect(html).not.toContain('<script>');
+    expect(html).not.toContain('<img src=x');
+    expect(html).not.toContain('<b>bold</b>');
+    expect(html).toContain('&lt;script&gt;alert(1)&lt;/script&gt;');
+    expect(html).toContain('&quot;quoted&quot; &amp; &lt;b&gt;bold&lt;/b&gt;');
+  });
+
+  it('escapes the heading in the title as well as the body', () => {
+    const html = renderOAuthErrorPage({ heading: '</title><script>x</script>', message: 'm' });
+    expect(html).not.toContain('</title><script>');
+  });
+});

--- a/src/http/templates/oauth-error.ts
+++ b/src/http/templates/oauth-error.ts
@@ -1,0 +1,107 @@
+/**
+ * OAuth Error Page HTML Template
+ *
+ * The OAuth authorize endpoint is reached by a browser navigation, not by the
+ * MCP client's own fetch — so when it fails, the only party who can see the
+ * response is the person staring at the tab. A JSON error body tells them
+ * nothing they can act on. This page tells them what to do instead.
+ */
+
+export interface OAuthErrorPageOptions {
+  heading: string;
+  message: string;
+  /** Optional literal the user should run or check. Rendered as code. */
+  action?: string;
+}
+
+export function renderOAuthErrorPage(options: OAuthErrorPageOptions): string {
+  const { heading, message, action } = options;
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <title>${escapeHtml(heading)} - InsForge MCP</title>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+
+    body {
+      font-family: 'Manrope', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+      background: #0F0F0F;
+      color: #e5e5e5;
+      min-height: 100vh;
+      padding: 60px 20px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      position: relative;
+    }
+
+    body::before {
+      content: '';
+      position: fixed;
+      inset: 0;
+      background-image: radial-gradient(circle, rgba(255,255,255,0.08) 1px, transparent 1px);
+      background-size: 24px 24px;
+      pointer-events: none;
+    }
+
+    .card {
+      position: relative;
+      width: 100%;
+      max-width: 560px;
+      background: linear-gradient(135deg, #1C1C1C 0%, #171717 100%);
+      border: 1px solid rgba(255, 255, 255, 0.08);
+      border-radius: 16px;
+      padding: 40px;
+    }
+
+    h1 {
+      font-size: 22px;
+      font-weight: 700;
+      margin-bottom: 14px;
+      color: #ffffff;
+    }
+
+    p {
+      font-size: 15px;
+      line-height: 1.6;
+      color: rgba(255, 255, 255, 0.66);
+    }
+
+    code {
+      display: block;
+      margin-top: 24px;
+      padding: 14px 16px;
+      font-family: 'SF Mono', Monaco, 'Cascadia Code', monospace;
+      font-size: 13px;
+      color: #6EE7B7;
+      background: rgba(110, 231, 183, 0.1);
+      border: 1px solid rgba(110, 231, 183, 0.2);
+      border-radius: 10px;
+      word-break: break-all;
+    }
+  </style>
+</head>
+<body>
+  <div class="card">
+    <h1>${escapeHtml(heading)}</h1>
+    <p>${escapeHtml(message)}</p>
+    ${action ? `<code>${escapeHtml(action)}</code>` : ''}
+  </div>
+</body>
+</html>`;
+}
+
+function escapeHtml(text: string): string {
+  return text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#039;');
+}


### PR DESCRIPTION
Fixes the 30-day registration expiry @qa-bot found and @manager scoped. Own PR rather than #71, since it shares nothing with the session leak.

## The bug

`server.ts` writes the registration with a 30-day TTL at `/oauth/register` and the read in `/oauth/authorize` never refreshes it. So this was never "stale after 30 days of disuse" — **every client stops working exactly 30 days after it registered, however heavily it has been used in between.** Some connected clients are already past that line, and the failure is silent from their side.

## Two changes, and nothing else

**1. Refresh the TTL once the registration has been read and validated.** That turns a fixed lifetime into an idle timeout for any client that keeps *authorizing*.

> **Correction (@qa-bot, measured):** I first wrote "an actively-used client stops expiring at all." That is wider than the change. Registrations slide only at `/oauth/authorize`; token bindings slide on every authenticated request. So the ordinary user — signs in once, then only calls tools — never returns to authorize, and their registration still dies 30 days after it was written. This PR strictly improves matters and the recovery path below is what they land on; it just does not cover that population. #75 does. A failed refresh is logged and swallowed — the worst case is the record keeping its old expiry, and the login itself must not fail on it.

**2. Answer the already-dead clients with something a person can act on.** Nothing here can recover automatically, and it's worth being precise about why:

- The MCP SDK only re-registers on an `InvalidClientError` from the **token** endpoint or from registration — `client/auth.js:152`, `invalidateCredentials('all')`.
- `/oauth/authorize` is a **browser navigation**. The SDK builds the URL and hands it to the browser; it never fetches or parses the response.
- Reaching `/oauth/token` requires an authorization code, which requires `/oauth/authorize` to have succeeded. So a dead registration can never produce the error that would heal it.

The only party who sees this response is the person looking at the tab, and a raw OAuth JSON body tells them nothing. They now get a page saying the connection needs adding again, naming the command. Programmatic callers get the identical JSON; a request with no `Accept` header gets JSON too.

### Deliberately not included

- **A `WWW-Authenticate` hint on the 400.** It has the same shape as #69's 401 but no consumer — per the above, the SDK never reads this response. A spec-shaped header nothing parses is worse than nothing, because it reads as a fix.
- **Validating `client_id` at `/oauth/token`.** It's the endpoint the SDK *does* watch, but the flow dies at authorize before ever reaching it, so it would add a rejection path that never fires in this scenario.
- **Any registration-lifecycle redesign.** Registrations become a signed, stateless value in the platform-OAuth rewrite. Both changes here sit on routes that rewrite deletes outright, so neither is work to un-build.

## Measured, both sides

Real built server, real Redis, real `/oauth/register` + `/oauth/authorize`. Pre-fix column is the same script against `master`.

| | pre-fix | post-fix |
|---|---|---|
| TTL at registration | 2592000 | 2592000 |
| TTL after aging the record to 120s | 120 | 120 |
| **TTL after a successful `/oauth/authorize`** | **120** — unchanged, still counting down | **2592000** — refreshed |
| authorize result | 302 | 302 |
| browser sees on a dead registration | raw JSON `invalid_client` | an actionable page, `400 text/html` |
| program sees on a dead registration | same JSON | same JSON, byte-identical |
| no `Accept` header | JSON | JSON |

27/27 tests green, 4 new on the template — including that every field is escaped, so the page stays safe if someone later reflects a `client_id` or `redirect_uri` into it.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops active clients from dying after 30 days by refreshing the registration TTL on successful authorize, and shows an actionable HTML page for already-expired registrations so users know how to fix it.

- **Bug Fixes**
  - Refresh the client registration TTL on authorize, turning the fixed 30-day lifetime into an idle timeout. Failures are logged and ignored so login isn’t blocked.

- **New Features**
  - When an unknown/expired client_id hits authorize and the request prefers HTML, return a clear page with instructions (e.g., run `npx @insforge/install`). Programmatic callers still get the same JSON error. Added tests to ensure all template fields are safely escaped.

<sup>Written for commit a4ecce33c3f69a13e253ac4ff378096fc27013b8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/insforge-mcp/pull/74?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


