### PR TITLE
Slide the client registration whenever its token is used

### DIFF
--- a/src/http/oauth-manager.test.ts
+++ b/src/http/oauth-manager.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const redisGet = vi.fn();
+const redisSetex = vi.fn();
+const redisExpire = vi.fn();
+
+vi.mock('./redis.js', () => ({
+  getRedisClient: () => ({ get: redisGet, setex: redisSetex, expire: redisExpire }),
+}));
+
+// The manager pulls in the whole platform API surface at import time; none of
+// it is on touchBinding's path.
+vi.mock('./insforge-api.js', () => ({
+  validateToken: vi.fn(),
+  getProjectAccess: vi.fn(),
+  getAllUserProjects: vi.fn(),
+  InsforgeApiError: class extends Error {},
+}));
+
+const { getOAuthManager, CLIENT_REGISTRATION_PREFIX, CLIENT_REGISTRATION_TTL } = await import(
+  './oauth-manager.js'
+);
+
+const TOKEN_HASH = 'a'.repeat(64);
+
+function binding(extra: Record<string, unknown> = {}) {
+  return JSON.stringify({
+    tokenHash: TOKEN_HASH,
+    userId: 'u1',
+    userEmail: 'user@example.com',
+    projectId: 'p1',
+    projectName: 'Project',
+    organizationId: 'o1',
+    accessHost: 'https://p1.example.com',
+    apiKey: 'ik_test',
+    createdAt: 1,
+    lastUsedAt: 1,
+    ...extra,
+  });
+}
+
+describe('OAuthManager.touchBinding', () => {
+  beforeEach(() => {
+    redisGet.mockReset();
+    redisSetex.mockReset().mockResolvedValue('OK');
+    redisExpire.mockReset().mockResolvedValue(1);
+  });
+
+  it('slides the client registration on the same beat as the binding', async () => {
+    // The whole point: a binding renews on every authenticated request, but the
+    // registration behind it only renewed at /oauth/authorize — which an
+    // ordinary user never returns to after signing in once.
+    redisGet.mockResolvedValue(binding({ clientId: 'mcp_abc' }));
+
+    await getOAuthManager().touchBinding(TOKEN_HASH);
+
+    expect(redisSetex).toHaveBeenCalled();
+    expect(redisExpire).toHaveBeenCalledWith(
+      CLIENT_REGISTRATION_PREFIX + 'mcp_abc',
+      CLIENT_REGISTRATION_TTL
+    );
+  });
+
+  it('leaves the registration alone for a binding with no clientId', async () => {
+    // Every binding written before this field existed, plus the direct bind
+    // API, where there is no registered OAuth client at all.
+    redisGet.mockResolvedValue(binding());
+
+    await getOAuthManager().touchBinding(TOKEN_HASH);
+
+    expect(redisSetex).toHaveBeenCalled();
+    expect(redisExpire).not.toHaveBeenCalled();
+  });
+
+  it('does not fail the request when the registration refresh throws', async () => {
+    // A TTL refresh is housekeeping. Losing it costs the registration its
+    // extension, not the user their request.
+    redisGet.mockResolvedValue(binding({ clientId: 'mcp_abc' }));
+    redisExpire.mockRejectedValue(new Error('READONLY'));
+    const logged = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await expect(getOAuthManager().touchBinding(TOKEN_HASH)).resolves.toBeUndefined();
+
+    expect(redisSetex).toHaveBeenCalled();
+    expect(logged).toHaveBeenCalled();
+    logged.mockRestore();
+  });
+
+  it('touches nothing at all when the binding is gone', async () => {
+    redisGet.mockResolvedValue(null);
+
+    await getOAuthManager().touchBinding(TOKEN_HASH);
+
+    expect(redisSetex).not.toHaveBeenCalled();
+    expect(redisExpire).not.toHaveBeenCalled();
+  });
+});

--- a/src/http/oauth-manager.ts
+++ b/src/http/oauth-manager.ts
@@ -73,17 +73,32 @@ interface TokenBinding {
   apiKey: string;
   createdAt: number;
   lastUsedAt: number;
+  /**
+   * The registration this binding was issued through, so ordinary use can keep
+   * that registration alive. Optional on purpose: bindTokenToProject serves the
+   * direct bind API, where there is no registered OAuth client at all. Also
+   * absent from every binding written before this field existed.
+   */
+  clientId?: string;
 }
 
 // Redis key prefixes
 const AUTH_STATE_PREFIX = 'mcp:auth:state:';
 const TOKEN_BINDING_PREFIX = 'mcp:auth:binding:';
 const AUTH_CODE_PREFIX = 'mcp:auth:code:';
+export const CLIENT_REGISTRATION_PREFIX = 'mcp:oauth:client:';
 
 // TTLs
 const AUTH_STATE_TTL = 10 * 60; // 10 minutes
 const AUTH_CODE_TTL = 5 * 60; // 5 minutes
 const TOKEN_BINDING_TTL = 30 * 24 * 60 * 60; // 30 days
+/**
+ * How long a client registration survives without being used.
+ *
+ * Refreshed alongside the binding on every authenticated request, and at
+ * /oauth/authorize, so this is an idle timeout rather than a lifetime.
+ */
+export const CLIENT_REGISTRATION_TTL = 30 * 24 * 60 * 60; // 30 days
 
 /**
  * Generate a hash of the token for storage
@@ -195,6 +210,7 @@ export class OAuthManager {
       apiKey: projectAccess.apiKey,
       createdAt: Date.now(),
       lastUsedAt: Date.now(),
+      clientId: authState.clientId,
     };
 
     // Store the binding
@@ -314,6 +330,21 @@ export class OAuthManager {
         TOKEN_BINDING_TTL,
         JSON.stringify(binding)
       );
+
+      // Slide the registration on the same beat. Without this the two records
+      // renew on different events: the binding on every authenticated request,
+      // the registration only at /oauth/authorize. An ordinary user signs in
+      // once and then only calls tools, so their token renews forever while
+      // the registration behind it still dies on a fixed schedule.
+      if (binding.clientId) {
+        try {
+          await redis.expire(CLIENT_REGISTRATION_PREFIX + binding.clientId, CLIENT_REGISTRATION_TTL);
+        } catch (error) {
+          // Never fail a request over a TTL refresh; the worst case is the
+          // registration keeping the expiry it already had.
+          console.error(`[OAuthManager] Could not refresh registration TTL for ${binding.clientId}:`, error);
+        }
+      }
     }
   }
 

--- a/src/http/server.ts
+++ b/src/http/server.ts
@@ -9,7 +9,11 @@ import { SSEServerTransport } from '@modelcontextprotocol/sdk/server/sse.js';
 // Local imports
 import { getSessionManager } from './session-manager.js';
 import { getRedisClient, closeRedisClient, getRedisConfig } from './redis.js';
-import { getOAuthManager } from './oauth-manager.js';
+import {
+  getOAuthManager,
+  CLIENT_REGISTRATION_PREFIX,
+  CLIENT_REGISTRATION_TTL,
+} from './oauth-manager.js';
 import {
   SERVER_CONFIG,
   INSFORGE_CONFIG,
@@ -79,17 +83,6 @@ function isInitializeRequest(body: unknown): boolean {
 
   return false;
 }
-
-/**
- * How long a client registration survives without being used.
- *
- * Refreshed on every successful authorize (see below), so this is an idle
- * timeout rather than a hard lifetime. It used to be neither: the value was
- * written once at registration and never touched again, so every client
- * stopped working exactly 30 days after it registered no matter how heavily
- * it was being used.
- */
-const CLIENT_REGISTRATION_TTL = 30 * 24 * 60 * 60;
 
 /**
  * Whether this request is a browser navigation rather than a program's fetch.
@@ -239,7 +232,7 @@ app.post(OAUTH_ENDPOINTS.register, async (req: Request, res: Response) => {
   };
 
   await redis.setex(
-    `mcp:oauth:client:${clientId}`,
+    CLIENT_REGISTRATION_PREFIX + clientId,
     CLIENT_REGISTRATION_TTL,
     JSON.stringify(clientData)
   );
@@ -290,7 +283,7 @@ app.get(OAUTH_ENDPOINTS.authorize, async (req: Request, res: Response) => {
 
   // Validate client_id and redirect_uri
   const redis = getRedisClient();
-  const clientKey = `mcp:oauth:client:${client_id}`;
+  const clientKey = CLIENT_REGISTRATION_PREFIX + client_id;
   const clientDataStr = await redis.get(clientKey);
   if (!clientDataStr) {
     // Nothing here can recover automatically. The MCP SDK only re-registers on


### PR DESCRIPTION
Follow-up to #74, from @qa-bot's correction. **Stacked on `fix/client-registration-expiry`** so #74 can ship on its own; I'll retarget to `master` once it merges.

## The gap

#74 refreshes a registration at `/oauth/authorize`. That covers a client that keeps *authorizing* — which is not the same population as a client that is merely *in use*.

- Token bindings renew on **every authenticated request** (`resolveProjectFromToken` → `touchBinding`).
- Registrations renewed **only at `/oauth/authorize`**.

So the ordinary user — signs in once, then only calls tools — renews their token forever while the registration behind it still dies on a fixed schedule from the day it was written. It stays invisible until something forces a re-auth, and then they hit the dead end.

## The change

`TokenBinding` had no way to name its registration, so `touchBinding` had nothing to refresh. Carry `clientId` on the binding where it's created (`authState.clientId` is already in scope there) and refresh both records on the same beat.

`clientId` is **optional on purpose**: `bindTokenToProject` serves the direct bind API, where no registered OAuth client is involved at all, and every binding written before this field existed lacks it too. A refresh failure is logged and swallowed — it's housekeeping, and losing it costs the registration its extension rather than the user their request.

Also moves the registration key prefix and TTL into `oauth-manager.ts` beside the other OAuth prefixes, so #74's authorize-path refresh and this one share a single definition instead of repeating the literal.

## Measured, real Redis

Both keys aged to 120s, then one `touchBinding` — which is what every authenticated MCP request runs:

| binding | binding TTL after use | registration TTL after use |
|---|---|---|
| carries `clientId` (written from this change on) | 2592000 | **2592000** |
| predates the field (everything in Redis today) | 2592000 | **120** |

### The second row is the honest limit of this change

Bindings already in Redis **cannot be repaired** — nothing records which registration issued them, and guessing at that mapping is not something to do on a security-adjacent key. So this stops the bleed from the next sign-in onward rather than rescuing the ~623 clients already connected. Those keep their original expiry, and if something forces them to re-auth they land on #74's recovery page, which is exactly the case #74 was built for.

The two changes are complementary, and neither is complete alone.

31/31 tests, 4 new on `touchBinding` — including that a binding with no `clientId` touches no registration, and that a failing refresh doesn't fail the request.

**Not tested:** a full round trip against the platform AS, or prod.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Active OAuth clients no longer expire while their tokens keep working. We now slide the client registration TTL on every authenticated request by carrying `clientId` on token bindings.

- **Bug Fixes**
  - Store optional `clientId` on token bindings and refresh the registration TTL in `touchBinding`.
  - Old bindings without `clientId` keep working but do not refresh the registration.
  - Log and ignore registration TTL refresh failures to avoid breaking requests.
  - Centralize `CLIENT_REGISTRATION_PREFIX` and `CLIENT_REGISTRATION_TTL` in `oauth-manager` and use them in register/authorize; add tests for `touchBinding`.

<sup>Written for commit 9fa55191a628ee84024dad8dbfdcfe7d83a13b3d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/insforge-mcp/pull/75?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

