### PR TITLE
Remote mode ignores a caller-supplied apiKey

### DIFF
--- a/src/shared/tools/api-key-binding.test.ts
+++ b/src/shared/tools/api-key-binding.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { registerInsforgeTools } from './index.js';
+import { sdkToolHost } from './host.js';
+
+/**
+ * In remote mode the project credential is bound to the session at sign-in.
+ * Several tools also expose an optional `apiKey` argument, which exists for the
+ * self-hosted stdio mode where the caller legitimately supplies its own
+ * credential. Honouring that argument in remote mode would mean the session
+ * credential is not authoritative — a caller could substitute any key it knows.
+ *
+ * These tests pin which key actually reaches the backend, per mode, by watching
+ * the outgoing request rather than by reasoning about the closure.
+ */
+
+const SESSION_KEY = 'ik_bound_to_the_session';
+const CALLER_KEY = 'ik_supplied_by_the_caller';
+
+const sentKeys: string[] = [];
+
+function keyOf(init?: { headers?: Record<string, string> }): string | undefined {
+  return init?.headers?.['x-api-key'];
+}
+
+function reply(body: unknown, status = 200) {
+  return {
+    ok: status < 400,
+    status,
+    headers: { get: () => 'application/json' },
+    json: async () => body,
+    text: async () => JSON.stringify(body),
+  };
+}
+
+// The tool modules do `import fetch from 'node-fetch'`, so the global is never
+// consulted — mocking it would silently test nothing.
+vi.mock('node-fetch', () => ({
+  default: vi.fn(async (input: unknown, init?: { headers?: Record<string, string> }) => {
+    const url = String(input);
+    if (url.endsWith('/api/health')) {
+      return reply({ version: '1.2.0' });
+    }
+    const key = keyOf(init);
+    if (key) sentKeys.push(key);
+    return reply({ ok: true });
+  }),
+}));
+
+beforeEach(() => {
+  sentKeys.length = 0;
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+/** Fail loudly rather than silently testing a tool that has no apiKey argument. */
+function requireTool(tools: Map<string, (args: any) => any>, name: string) {
+  const tool = tools.get(name);
+  if (!tool) throw new Error(`no tool named ${name}; got: ${[...tools.keys()].join(', ')}`);
+  return tool;
+}
+
+/** Register against a real McpServer and return the callable tool map. */
+async function toolsFor(mode: 'remote' | undefined) {
+  const server = new McpServer({ name: 'test', version: '0.0.0' });
+  const captured = new Map<string, (args: any) => any>();
+  const host = sdkToolHost(server);
+  const spy = {
+    registerTool(name: string, description: string, schema: any, handler: any) {
+      captured.set(name, handler);
+      host.registerTool(name, description, schema, handler);
+    },
+  };
+
+  await registerInsforgeTools(spy, {
+    apiKey: SESSION_KEY,
+    apiBaseUrl: 'https://project.example.com',
+    mode,
+    projectId: 'proj_1',
+    accessToken: 'tok',
+  });
+
+  return captured;
+}
+
+describe('which api key reaches the backend', () => {
+  it('remote mode ignores a caller-supplied apiKey and uses the session credential', async () => {
+    const tools = await toolsFor('remote');
+    const tool = requireTool(tools, 'get-table-schema');
+
+    await tool({ apiKey: CALLER_KEY, tableName: 't' }).catch(() => {});
+
+    expect(sentKeys.length).toBeGreaterThan(0);
+    expect(sentKeys).not.toContain(CALLER_KEY);
+    expect(sentKeys.every((k) => k === SESSION_KEY)).toBe(true);
+  });
+
+  it('self-hosted mode still honours it, because that is how stdio is configured', async () => {
+    // Not a bug there: the operator running the binary supplies the key.
+    const tools = await toolsFor(undefined);
+    const tool = requireTool(tools, 'get-table-schema');
+
+    await tool({ apiKey: CALLER_KEY, tableName: 't' }).catch(() => {});
+
+    expect(sentKeys).toContain(CALLER_KEY);
+  });
+
+  it('remote mode with no argument at all is unchanged', async () => {
+    const tools = await toolsFor('remote');
+    const tool = requireTool(tools, 'get-table-schema');
+
+    await tool({ tableName: 't' }).catch(() => {});
+
+    expect(sentKeys.every((k) => k === SESSION_KEY)).toBe(true);
+  });
+});

--- a/src/shared/tools/index.ts
+++ b/src/shared/tools/index.ts
@@ -237,7 +237,14 @@ export async function registerInsforgeTools(host: ToolHost, config: ToolsConfig 
   }
 
   const getApiKey = (toolApiKey?: string): string => {
-    const apiKey = toolApiKey?.trim() || GLOBAL_API_KEY;
+    // The per-call apiKey argument exists for the self-hosted stdio mode, where
+    // the caller legitimately supplies its own credential. In remote mode the
+    // credential is bound to the session at sign-in, and honouring a
+    // caller-supplied one would mean the session credential is not
+    // authoritative — an agent could substitute any key it happens to know.
+    // The fixed per-session base URL keeps that inside one project, so this is
+    // not cross-project access, but it is still an override nobody needs here.
+    const apiKey = (isRemote ? undefined : toolApiKey?.trim()) || GLOBAL_API_KEY;
     if (!apiKey) {
       throw new Error('API key is required. Pass --api_key when starting the MCP server.');
     }


### PR DESCRIPTION
Came out of checking @infra-bot's item 5 ("wrong project is REFUSED") in source rather than leaving it as an assumption for QA. **The premise turned out to be wrong, and checking it found a different thing that is real.**

## `projectId` is not a tool argument

```
tools taking projectId as an input argument:  0
how it enters:  registerInsforgeTools(host, { projectId, ... })  — bound per session at sign-in
```

So "an agent names someone else's project" isn't reachable through a tool argument today. Good news, but it means the protection isn't where it was thought to be.

## `apiKey` *is* a tool argument, and it won

```js
const apiKey = toolApiKey?.trim() || GLOBAL_API_KEY;   // caller wins
```

14 tools across `database.ts`, `storage.ts`, `functions.ts`, `docs.ts` expose `apiKey: z.string().optional()`. That exists for the self-hosted stdio mode, where the operator running the binary legitimately supplies the credential. In remote mode the credential is bound to the session, so honouring it means **the session credential is not authoritative** — an agent can substitute any key it knows.

### Scope, stated precisely rather than alarmingly

`apiBaseUrl` is **not** a tool argument — it's fixed per session. So a key for another project sent to *this* project's host does not authenticate. **This is not cross-project access.** What it is:

- an override nobody needs in remote mode, and
- a way to swap the session's credential for a different one against the same project — an escalation if the session was bound with a lesser key than the caller supplies (`anon_` vs `ik_`).

## The change

Ignored in remote mode only. stdio is unchanged, because there the argument *is* the configuration mechanism. One line, no schema change, so no client breaks.

## Tests

They pin which key actually reaches the backend by watching the outgoing request per mode, rather than reasoning about the closure. Two things worth noting:

- They mock **`node-fetch`**, not the global — the tool modules `import fetch from 'node-fetch'`, so mocking `globalThis.fetch` would have silently tested nothing. My first attempt did exactly that and failed loudly, which is the only reason I noticed.
- **Confirmed they have teeth:** reverting the one-line change fails the remote case, and only the remote case.

26/26 green.

## For @qa-bot

This narrows what's worth your time on item 5: the projectId vector doesn't exist, so the test to run is *credential substitution within a session*, plus the original question of whether `getProjectApiKey` refuses a project the authenticated user doesn't own — which is platform-side and unaffected by this PR.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remote mode now ignores a caller-supplied `apiKey` and always uses the session credential. This blocks within-project credential swapping and does not allow cross-project access; stdio mode is unchanged.

- **Bug Fixes**
  - Change: In remote mode, `getApiKey` drops the per-call `apiKey` and uses the session/global key; stdio still honors the argument.
  - Tests: Added coverage that inspects outgoing requests (mocking `node-fetch`) to confirm the correct key is sent per mode.

<sup>Written for commit db782037ee2401161b80ef46732248cc42401c4d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/insforge-mcp/pull/76?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved API key handling in remote mode by consistently using the session credential.
  * Preserved per-call API key overrides for self-hosted and local deployments.
  * Maintained existing behavior when no per-call API key is provided.

* **Tests**
  * Added coverage verifying API key behavior across remote and self-hosted runtime modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->