### PR TITLE
Make the container actually able to start

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "insforge-mcp-server": "./dist/http-server.js"
   },
   "scripts": {
+    "start": "node dist/http-server.js --host 0.0.0.0",
     "dev:stdio": "tsx watch src/stdio/index.ts",
     "dev:http": "tsx watch src/http/server.ts",
     "build": "tsup",

--- a/src/http/config.ts
+++ b/src/http/config.ts
@@ -10,8 +10,11 @@ program
   .name('insforge-mcp-server')
   .description('HTTP MCP server for Insforge backend-as-a-service')
   .version(PACKAGE_VERSION, '-v, --version')
-  .option('--port <number>', 'Port to run HTTP server on', '3000')
-  .option('--host <string>', 'Host to bind to', '127.0.0.1');
+  // Defaults come from the environment so a container platform's injected
+  // PORT/HOST are honoured. An explicit flag still wins: commander only
+  // applies a default when the flag is absent.
+  .option('--port <number>', 'Port to run HTTP server on', process.env.PORT || '3000')
+  .option('--host <string>', 'Host to bind to', process.env.HOST || '127.0.0.1');
 program.parse(process.argv);
 
 const cliOptions = program.opts();
@@ -21,10 +24,23 @@ const cliOptions = program.opts();
 // ============================================================================
 
 export const SERVER_CONFIG = {
-  /** Port to run HTTP server on */
+  /**
+   * Port to run HTTP server on.
+   *
+   * Sourced from PORT when no flag is given — every container platform assigns
+   * one that way and nothing here was reading it, so a hosted deploy bound
+   * 3000 regardless of what it had been told to use.
+   */
   port: parseInt(cliOptions.port) || 3000,
 
-  /** Host to bind to */
+  /**
+   * Host to bind to.
+   *
+   * Stays loopback unless asked otherwise: a locally-run binary should not be
+   * reachable from the network. A container opts in with --host 0.0.0.0 or
+   * HOST, which the start script does explicitly so it is visible rather than
+   * implied.
+   */
   host: cliOptions.host || '127.0.0.1',
 
   /** Public URL of this MCP server */


### PR DESCRIPTION
@tony pasted a deployment log and it names the cause of every failed Manufact deploy. **It was not Redis.**

```
npm error Missing script: "start"
INFO Main child exited normally with code: 1
[   12.255664] reboot: Restarting system
```

The platform runs `npm start`. There is no `start` script, so npm exits 1 **before any of our code runs**, the container restarts, and it loops. That's why no runtime log ever reached us, why `/health` kept answering the platform's placeholder, and why 19 deploys produced no diagnosis. Merging the Redis fix would not have changed it — and I was one of the people saying it would.

Reproduces on master: `npm start` prints exactly the error above.

## Two more sat behind it

Each would have caused the *next* deploy to fail differently:

**Nothing read `PORT`.** Both `--port` and `--host` had hardcoded commander defaults, so `cliOptions.port` was never empty and an injected `PORT` was ignored — the process would bind 3000 whatever the platform assigned. (I initially "fixed" this with a fallback *after* `cliOptions.port`, which was dead code for exactly that reason. Caught by testing it, not by reading it.) Defaults now come from `PORT`/`HOST` when the flag is absent; an explicit flag still wins, since commander only applies a default when the flag isn't given.

**Default host is `127.0.0.1`.** Even once it started it would accept only loopback and the edge couldn't reach it. The start script sets `--host 0.0.0.0` explicitly rather than changing the default — a locally-run binary stays off the network, and the container's exposure is visible in the script rather than implied.

## Verified against the built artifact

| case | result |
|---|---|
| `npm start`, `PORT=8471` injected | `0.0.0.0:8471`, `/health` 200 |
| `--port 8472` with `PORT=9999` | `127.0.0.1:8472` — flag wins |
| `PORT` set, no flags | uses `PORT` |
| `PORT` unset, no flags | `127.0.0.1:3000` — unchanged |

23/23, tsc and eslint clean.

## Still unverified

Whether the platform runs a build step. There's no `prepare` script, so if it only installs and starts, `dist/` won't exist and the next error will be a missing module rather than a missing script. I've left that alone rather than guessing — the next deploy log will say. If it does turn out to need one, `"prepare": "npm run build"` is the fix.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes container boot loops by adding a proper start command and honoring `PORT`/`HOST` so the server starts and is reachable in deploys. Local runs stay on loopback; the container binds to `0.0.0.0`.

- **Bug Fixes**
  - Add `start` script: `node dist/http-server.js --host 0.0.0.0`.
  - Use `PORT` and `HOST` as defaults when flags aren’t provided; explicit flags still win.
  - Keep default host as `127.0.0.1` for local safety; container exposure is explicit via the script.

<sup>Written for commit c58d5d03f63ba13e9ec40c445b083d070960553b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/insforge-mcp/pull/78?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

