### PR TITLE
Client registrations as signed ids, not Redis rows

### DIFF
--- a/src/http/client-id.test.ts
+++ b/src/http/client-id.test.ts
@@ -3,7 +3,6 @@ import {
   mintClientId,
   readClientId,
   isRegisteredRedirectUri,
-  generateSigningSecret,
   InvalidClientIdError,
 } from './client-id.js';
 
@@ -107,16 +106,21 @@ describe('redirect_uri matching', () => {
   });
 });
 
-describe('generateSigningSecret', () => {
-  it('produces distinct high-entropy secrets', () => {
-    const a = generateSigningSecret();
-    const b = generateSigningSecret();
-    expect(a).not.toBe(b);
-    expect(a.length).toBeGreaterThanOrEqual(32);
+describe('a missing secret is never silently substituted', () => {
+  it('refuses to mint or read without one', () => {
+    // Quinn's catch: a per-boot generated fallback would invalidate every
+    // client id on every restart, handing every user the re-add page at once
+    // — a mass logout dressed up as a convenience. There is deliberately no
+    // way to get a working signer without supplying the secret, so wiring
+    // cannot reach for one by accident.
+    for (const missing of ['', undefined as unknown as string, null as unknown as string]) {
+      expect(() => mintClientId({ redirect_uris: [CALLBACK] }, missing)).toThrow();
+      expect(() => readClientId('mcp_a.b', missing)).toThrow();
+    }
   });
 
-  it('ids minted under one generated secret do not verify under another', () => {
-    const id = mintClientId({ redirect_uris: [CALLBACK] }, generateSigningSecret());
-    expect(() => readClientId(id, generateSigningSecret())).toThrow(InvalidClientIdError);
+  it('exports no secret generator', async () => {
+    const mod = await import('./client-id.js');
+    expect(Object.keys(mod)).not.toContain('generateSigningSecret');
   });
 });

--- a/src/http/client-id.test.ts
+++ b/src/http/client-id.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect } from 'vitest';
+import {
+  mintClientId,
+  readClientId,
+  isRegisteredRedirectUri,
+  generateSigningSecret,
+  InvalidClientIdError,
+} from './client-id.js';
+
+const SECRET = 'test-signing-secret';
+const OTHER_SECRET = 'a-different-signing-secret';
+const CALLBACK = 'http://127.0.0.1:8765/callback';
+
+describe('client ids carry their own registration', () => {
+  it('round-trips what the client registered', () => {
+    const id = mintClientId({ redirect_uris: [CALLBACK], client_name: 'Claude Code' }, SECRET);
+    const reg = readClientId(id, SECRET);
+
+    expect(reg.redirect_uris).toEqual([CALLBACK]);
+    expect(reg.client_name).toBe('Claude Code');
+    expect(typeof reg.iat).toBe('number');
+  });
+
+  it('is recognisable as ours', () => {
+    expect(mintClientId({ redirect_uris: [CALLBACK] }, SECRET).startsWith('mcp_')).toBe(true);
+  });
+
+  it('does not expire', () => {
+    // The stored version expired after 30 days and silently broke every client
+    // installed that long. A redirect_uri does not go stale.
+    const tenYearsAgo = Math.floor(Date.now() / 1000) - 10 * 365 * 24 * 60 * 60;
+    const id = mintClientId({ redirect_uris: [CALLBACK] }, SECRET, tenYearsAgo);
+
+    expect(readClientId(id, SECRET).redirect_uris).toEqual([CALLBACK]);
+  });
+});
+
+describe('a client id cannot be forged', () => {
+  it('rejects a payload edited to claim another redirect_uri', () => {
+    // The attack this whole module exists to stop: change where the code goes.
+    const id = mintClientId({ redirect_uris: [CALLBACK] }, SECRET);
+    const [payload, signature] = id.slice('mcp_'.length).split('.');
+    const tampered = Buffer.from(
+      JSON.stringify({ redirect_uris: ['https://attacker.example/steal'], iat: 1 })
+    ).toString('base64url');
+
+    expect(() => readClientId(`mcp_${tampered}.${signature}`, SECRET)).toThrow(InvalidClientIdError);
+    // and the original still verifies, so the test is about the edit, not the shape
+    expect(readClientId(`mcp_${payload}.${signature}`, SECRET).redirect_uris).toEqual([CALLBACK]);
+  });
+
+  it('rejects an id signed with a different secret', () => {
+    const id = mintClientId({ redirect_uris: [CALLBACK] }, OTHER_SECRET);
+    expect(() => readClientId(id, SECRET)).toThrow(InvalidClientIdError);
+  });
+
+  it('rejects ids that are not ours at all', () => {
+    for (const bad of ['', 'mcp_', 'mcp_nodot', 'mcp_.sig', 'mcp_payload.', 'random-string']) {
+      expect(() => readClientId(bad, SECRET)).toThrow(InvalidClientIdError);
+    }
+  });
+
+  it('rejects a signed payload that is not a registration', () => {
+    // Signed by us, but a shape we never intended to mint.
+    const payload = Buffer.from(JSON.stringify({ redirect_uris: [] })).toString('base64url');
+    const id = mintClientId({ redirect_uris: [CALLBACK] }, SECRET);
+    const signature = id.slice(id.lastIndexOf('.') + 1);
+    expect(() => readClientId(`mcp_${payload}.${signature}`, SECRET)).toThrow(InvalidClientIdError);
+  });
+
+  it('refuses to work without a secret', () => {
+    expect(() => mintClientId({ redirect_uris: [CALLBACK] }, '')).toThrow();
+    expect(() => readClientId('mcp_a.b', '')).toThrow();
+  });
+});
+
+describe('redirect_uri matching', () => {
+  const reg = readClientId(
+    mintClientId({ redirect_uris: [CALLBACK, 'https://app.example/cb'] }, SECRET),
+    SECRET
+  );
+
+  it('accepts a registered uri exactly', () => {
+    expect(isRegisteredRedirectUri(reg, CALLBACK)).toBe(true);
+    expect(isRegisteredRedirectUri(reg, 'https://app.example/cb')).toBe(true);
+  });
+
+  it('rejects prefix and origin near-misses', () => {
+    // These are the relaxations that turn a redirect_uri check into an open
+    // redirect, which on an authorize endpoint is code theft.
+    for (const near of [
+      'http://127.0.0.1:8765/callback/../evil',
+      'http://127.0.0.1:8765/callback2',
+      'http://127.0.0.1:8765',
+      'https://app.example/cb?next=https://attacker.example',
+      'https://app.example.attacker.test/cb',
+      'HTTP://127.0.0.1:8765/callback',
+    ]) {
+      expect(isRegisteredRedirectUri(reg, near)).toBe(false);
+    }
+  });
+
+  it('rejects non-strings', () => {
+    for (const bad of [undefined, null, 42, ['a'], {}]) {
+      expect(isRegisteredRedirectUri(reg, bad)).toBe(false);
+    }
+  });
+});
+
+describe('generateSigningSecret', () => {
+  it('produces distinct high-entropy secrets', () => {
+    const a = generateSigningSecret();
+    const b = generateSigningSecret();
+    expect(a).not.toBe(b);
+    expect(a.length).toBeGreaterThanOrEqual(32);
+  });
+
+  it('ids minted under one generated secret do not verify under another', () => {
+    const id = mintClientId({ redirect_uris: [CALLBACK] }, generateSigningSecret());
+    expect(() => readClientId(id, generateSigningSecret())).toThrow(InvalidClientIdError);
+  });
+});

--- a/src/http/client-id.ts
+++ b/src/http/client-id.ts
@@ -1,4 +1,4 @@
-import { createHmac, randomBytes, timingSafeEqual } from 'crypto';
+import { createHmac, timingSafeEqual } from 'crypto';
 
 /**
  * Client registrations as signed values rather than stored rows.
@@ -126,9 +126,4 @@ export function isRegisteredRedirectUri(
   redirectUri: unknown
 ): boolean {
   return typeof redirectUri === 'string' && registration.redirect_uris.includes(redirectUri);
-}
-
-/** A signing secret for local runs, so the server starts without configuration. */
-export function generateSigningSecret(): string {
-  return randomBytes(32).toString('base64url');
 }

--- a/src/http/client-id.ts
+++ b/src/http/client-id.ts
@@ -1,0 +1,134 @@
+import { createHmac, randomBytes, timingSafeEqual } from 'crypto';
+
+/**
+ * Client registrations as signed values rather than stored rows.
+ *
+ * `/oauth/register` currently writes a Redis row and hands back a random id;
+ * `/oauth/authorize` reads that row back to learn the client's redirect_uris.
+ * That row is one of the five things keeping Redis on the critical path, and
+ * it is pure derived data — the only thing we learn from it is what the client
+ * already told us at registration.
+ *
+ * So carry it in the id. The id is `<payload>.<signature>`: the payload is the
+ * registration, the signature is ours. Anyone can read a client id (it travels
+ * in every authorize URL and is not a secret), but only we can mint one, which
+ * is the property that matters — an attacker cannot invent a client id that
+ * claims a redirect_uri we never approved.
+ *
+ * This is the mcp-use `oauthProxy` shape with the check that implementation
+ * omits: it never validates redirect_uri against the registration, which is
+ * what makes authorization-code theft possible there. Here the registration
+ * IS the id, so the check cannot be skipped by accident — there is nothing
+ * else to compare against.
+ */
+
+/** What a client told us about itself at registration. */
+export interface ClientRegistration {
+  redirect_uris: string[];
+  client_name?: string;
+  /** Seconds since epoch, for diagnostics. Not used for expiry — see below. */
+  iat: number;
+}
+
+export class InvalidClientIdError extends Error {}
+
+const PREFIX = 'mcp_';
+
+function sign(payload: string, secret: string): string {
+  return createHmac('sha256', secret).update(payload).digest('base64url');
+}
+
+/**
+ * Mint a client id that carries its own registration.
+ *
+ * Deliberately not time-limited. The stored version expired after 30 days and
+ * silently broke every client that had been installed that long — a bug we
+ * shipped and had to fix twice. A registration describes a redirect_uri, and a
+ * redirect_uri does not go stale; if we ever need to invalidate one, rotating
+ * the signing secret does it for all of them at once.
+ */
+export function mintClientId(
+  registration: Omit<ClientRegistration, 'iat'>,
+  secret: string,
+  now: number = Math.floor(Date.now() / 1000)
+): string {
+  if (!secret) {
+    throw new Error('a signing secret is required to mint client ids');
+  }
+  const full: ClientRegistration = { ...registration, iat: now };
+  const payload = Buffer.from(JSON.stringify(full)).toString('base64url');
+  return `${PREFIX}${payload}.${sign(payload, secret)}`;
+}
+
+/**
+ * Recover a registration from a client id, or throw.
+ *
+ * Throws rather than returning null so a caller cannot accidentally treat an
+ * unverified registration as valid by forgetting a null check — the failure
+ * mode this whole module exists to prevent.
+ */
+export function readClientId(clientId: string, secret: string): ClientRegistration {
+  if (!secret) {
+    throw new Error('a signing secret is required to read client ids');
+  }
+  if (typeof clientId !== 'string' || !clientId.startsWith(PREFIX)) {
+    throw new InvalidClientIdError('not a client id issued by this server');
+  }
+
+  const body = clientId.slice(PREFIX.length);
+  const dot = body.lastIndexOf('.');
+  if (dot <= 0 || dot === body.length - 1) {
+    throw new InvalidClientIdError('malformed client id');
+  }
+
+  const payload = body.slice(0, dot);
+  const provided = Buffer.from(body.slice(dot + 1));
+  const expected = Buffer.from(sign(payload, secret));
+
+  // Length-check first: timingSafeEqual throws on a length mismatch, and that
+  // throw would itself be a (crude) oracle.
+  if (provided.length !== expected.length || !timingSafeEqual(provided, expected)) {
+    throw new InvalidClientIdError('client id signature does not verify');
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(Buffer.from(payload, 'base64url').toString('utf8'));
+  } catch {
+    throw new InvalidClientIdError('client id payload is not JSON');
+  }
+
+  const reg = parsed as ClientRegistration;
+  if (
+    !reg ||
+    !Array.isArray(reg.redirect_uris) ||
+    reg.redirect_uris.length === 0 ||
+    !reg.redirect_uris.every((u) => typeof u === 'string' && u.length > 0)
+  ) {
+    // Signed by us but structurally wrong — treat as invalid rather than
+    // trusting a shape we did not intend to mint.
+    throw new InvalidClientIdError('client id payload is not a registration');
+  }
+
+  return reg;
+}
+
+/**
+ * Is this redirect_uri one the client registered?
+ *
+ * Exact string match, per RFC 6749 §3.1.2.3. No prefix or origin matching:
+ * those are the relaxations that turn a redirect_uri check into an open
+ * redirect, and an open redirect on an authorization endpoint is
+ * authorization-code theft.
+ */
+export function isRegisteredRedirectUri(
+  registration: ClientRegistration,
+  redirectUri: unknown
+): boolean {
+  return typeof redirectUri === 'string' && registration.redirect_uris.includes(redirectUri);
+}
+
+/** A signing secret for local runs, so the server starts without configuration. */
+export function generateSigningSecret(): string {
+  return randomBytes(32).toString('base64url');
+}


### PR DESCRIPTION
First piece of the no-Redis rewrite, and the one that stands alone. **No behaviour change** — the module isn't wired into `server.ts` yet; that lands with the `/oauth/register` and `/oauth/authorize` changes.

## Why this one first

`mcp:oauth:client:*` is one of the five things keeping Redis on the critical path, and it's pure derived data: the only thing we ever learn from that row is what the client told us at registration. So carry it in the id — `mcp_<payload>.<signature>`.

A client id **is not a secret** (it travels in every authorize URL), so the property that matters isn't confidentiality but unforgeability. Anyone can read one; only we can mint one. An attacker can't invent an id claiming a `redirect_uri` we never approved.

**This is the mcp-use `oauthProxy` shape with the check that implementation omits.** `oauthProxy` never validates `redirect_uri` against the registration — that's what makes authorization-code theft possible there. Here the registration *is* the id, so there's nothing else to compare against and the check can't be skipped by accident. Per @manager's framing: when platform DCR opens, this gets deleted and replaced by a library call, not rewritten.

## Deliberate choices

- **No expiry.** The stored version expired after 30 days and silently broke every client installed that long — a bug we shipped and then fixed twice (#74, #75). A `redirect_uri` doesn't go stale. Rotating the signing secret invalidates every registration at once if we ever need that.
- **`readClientId` throws rather than returning null**, so a caller can't treat an unverified registration as valid by forgetting a check.
- **Length-compared before `timingSafeEqual`**, which throws on a length mismatch — that throw would itself be a crude oracle.
- **Exact-match `redirect_uris`** per RFC 6749 §3.1.2.3. No prefix or origin matching: those relaxations are what turn a redirect_uri check into an open redirect, and an open redirect on an authorize endpoint is code theft.

## Tests

13, including six redirect_uri near-misses — a path traversal, a suffix domain (`app.example.attacker.test`), a query-string append, a scheme-case variant.

**Confirmed they have teeth:** stubbing the signature comparison to always pass fails exactly the three forgery tests and nothing else.

```
× rejects a payload edited to claim another redirect_uri
× rejects an id signed with a different secret
× ids minted under one generated secret do not verify under another
```

58/58 across the suite, lint clean.

## Still to come on this branch

Wiring into `/oauth/register` (mint, store nothing) and `/oauth/authorize` (read the id, validate `redirect_uri` from it), plus the signing-secret config. Kept separate so this piece can be reviewed on its own security merits.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds support for stateless OAuth client registrations using signed client IDs. No behavior change yet; this module will be wired into `/oauth/register` and `/oauth/authorize` next.

- **New Features**
  - Signed client ID format: `mcp_<payload>.<signature>` (HMAC-SHA256). Payload includes `redirect_uris`, optional `client_name`, and `iat`.
  - APIs: `mintClientId`, `readClientId` (throws on invalid), `isRegisteredRedirectUri` (exact match per RFC 6749 §3.1.2.3).
  - Security: exact `redirect_uri` matching, no expiry by design (rotate secret to revoke), constant-time verification with a length check, and requires a configured signing secret (no fallback).

- **Bug Fixes**
  - Removed the per-boot secret generator to avoid accidental mass invalidation on restart; `mintClientId` and `readClientId` now error without a supplied secret.

<sup>Written for commit 8cf53508678edc26bcedbbed45c7c1fe3170a784. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/insforge-mcp/pull/79?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added self-contained OAuth client IDs with signed registration details.
  * Added support for validating client IDs, redirect URIs, expiration data, and signatures.
  * Added secure signing-secret generation.
* **Bug Fixes**
  * Improved handling of malformed, forged, or improperly configured client IDs.
* **Tests**
  * Added comprehensive coverage for client ID creation, validation, redirect matching, expiration, and signing-secret security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->