### PR TITLE
fix(http): normalise publicUrl at the source — missing from merged #69

### DIFF
--- a/src/http/auth-challenge.test.ts
+++ b/src/http/auth-challenge.test.ts
@@ -149,3 +149,67 @@ describe('normaliseBaseUrl', () => {
     expect(normaliseBaseUrl('https://host/base/')).toBe('https://host/base');
   });
 });
+
+describe('no advertised URL can contain a doubled slash', () => {
+  // Quinn's ask: assert on the URLs we advertise, not on the helper that
+  // builds them. A trailing slash on MCP_SERVER_URL used to break the login
+  // in at least three separate places, at three different steps — the AS
+  // metadata, the project-selection redirect, and the authorize links in 401
+  // bodies. Per-consumer patching missed two of them.
+  const SLASHED = 'https://mcp.insforge.dev/';
+
+  /** Everything after the scheme, so `https://` itself is not a false hit. */
+  const hasDoubledSlash = (url: string) => url.replace(/^[a-z]+:\/\//, '').includes('//');
+
+  it('not in the protected-resource documents', () => {
+    for (const path of ['', '/mcp', '/sse']) {
+      const doc = protectedResourceMetadata(path, SLASHED);
+      expect(hasDoubledSlash(String(doc.resource))).toBe(false);
+      for (const as of doc.authorization_servers as string[]) {
+        expect(hasDoubledSlash(as)).toBe(false);
+      }
+    }
+  });
+
+  it('not in the metadata URL a client derives', () => {
+    for (const path of ['', '/mcp', '/sse']) {
+      expect(hasDoubledSlash(protectedResourceMetadataUrl(path, SLASHED))).toBe(false);
+    }
+  });
+
+  it('not in the WWW-Authenticate challenge', () => {
+    for (const path of ['', '/mcp', '/sse']) {
+      const challenge = buildResourceChallenge(path, SLASHED);
+      const named = challenge.match(/resource_metadata="([^"]+)"/)?.[1] ?? '';
+      expect(named).not.toBe('');
+      expect(hasDoubledSlash(named)).toBe(false);
+    }
+  });
+});
+
+describe('nothing bypasses the normalisation', () => {
+  it('only config.ts reads MCP_SERVER_URL', async () => {
+    // publicUrl is normalised where it is defined, so every consumer is safe
+    // by construction. The one way to reintroduce the bug is to read the raw
+    // environment variable somewhere else, so that is what this forbids.
+    const { readdirSync, readFileSync, statSync } = await import('node:fs');
+    const { join } = await import('node:path');
+
+    const offenders: string[] = [];
+    const walk = (dir: string) => {
+      for (const entry of readdirSync(dir)) {
+        const full = join(dir, entry);
+        if (statSync(full).isDirectory()) {
+          walk(full);
+          continue;
+        }
+        if (!full.endsWith('.ts') || full.endsWith('.test.ts')) continue;
+        if (full.endsWith('http/config.ts')) continue;
+        if (/process\.env\.MCP_SERVER_URL/.test(readFileSync(full, 'utf8'))) offenders.push(full);
+      }
+    };
+    walk('src');
+
+    expect(offenders).toEqual([]);
+  });
+});

--- a/src/http/auth-challenge.test.ts
+++ b/src/http/auth-challenge.test.ts
@@ -187,29 +187,74 @@ describe('no advertised URL can contain a doubled slash', () => {
   });
 });
 
-describe('nothing bypasses the normalisation', () => {
-  it('only config.ts reads MCP_SERVER_URL', async () => {
-    // publicUrl is normalised where it is defined, so every consumer is safe
-    // by construction. The one way to reintroduce the bug is to read the raw
-    // environment variable somewhere else, so that is what this forbids.
-    const { readdirSync, readFileSync, statSync } = await import('node:fs');
-    const { join } = await import('node:path');
+/** Every non-test .ts under src, by absolute path. */
+async function sourceFiles(): Promise<string[]> {
+  const { readdirSync, statSync } = await import('node:fs');
+  const { join, dirname, resolve } = await import('node:path');
+  const { fileURLToPath } = await import('node:url');
 
-    const offenders: string[] = [];
-    const walk = (dir: string) => {
-      for (const entry of readdirSync(dir)) {
-        const full = join(dir, entry);
-        if (statSync(full).isDirectory()) {
-          walk(full);
-          continue;
-        }
-        if (!full.endsWith('.ts') || full.endsWith('.test.ts')) continue;
-        if (full.endsWith('http/config.ts')) continue;
-        if (/process\.env\.MCP_SERVER_URL/.test(readFileSync(full, 'utf8'))) offenders.push(full);
+  // Anchored to this file, not to process.cwd(). It happens to be the project
+  // root under vitest today, which is a property of how the tests are launched
+  // rather than of the tree being checked — and a guard that silently walks an
+  // empty directory passes.
+  const root = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+
+  const found: string[] = [];
+  const walk = (dir: string) => {
+    for (const entry of readdirSync(dir)) {
+      const full = join(dir, entry);
+      if (statSync(full).isDirectory()) {
+        walk(full);
+        continue;
       }
-    };
-    walk('src');
+      if (full.endsWith('.ts') && !full.endsWith('.test.ts')) found.push(full);
+    }
+  };
+  walk(root);
+  return found;
+}
+
+describe('nothing bypasses the normalisation', () => {
+  it('only config.ts mentions MCP_SERVER_URL at all', async () => {
+    // publicUrl is normalised where it is defined, so every consumer is safe by
+    // construction, and the one way to reintroduce the bug is to read the raw
+    // environment variable somewhere else.
+    //
+    // This forbids the NAME, not one syntax for reading it. The previous
+    // version matched /process\.env\.MCP_SERVER_URL/, so
+    // process.env['MCP_SERVER_URL'] and const { MCP_SERVER_URL } = process.env
+    // both walked straight past — a guard that does not guard, which is worse
+    // than none because it is counted as coverage. Nothing outside config.ts
+    // has any business naming the variable, so the name is the right thing to
+    // forbid and it has no syntax blind spots.
+    const { readFileSync } = await import('node:fs');
+
+    const offenders = (await sourceFiles()).filter(
+      (file) => !file.endsWith('http/config.ts') && readFileSync(file, 'utf8').includes('MCP_SERVER_URL')
+    );
 
     expect(offenders).toEqual([]);
+  });
+
+  it('is actually looking at files', async () => {
+    // The guard above passes vacuously if the walk finds nothing — which is
+    // exactly how a gate scores green without reaching the code it grades.
+    const files = await sourceFiles();
+    expect(files.length).toBeGreaterThan(5);
+    expect(files.some((f) => f.endsWith('http/config.ts'))).toBe(true);
+    expect(files.some((f) => f.endsWith('http/server.ts'))).toBe(true);
+  });
+
+  it('catches every way of naming the variable', async () => {
+    // The three forms that must all be caught, checked against the same
+    // predicate the guard uses rather than described in a comment.
+    const bypasses = [
+      "const u = process.env.MCP_SERVER_URL;",
+      "const u = process.env['MCP_SERVER_URL'];",
+      'const { MCP_SERVER_URL } = process.env;',
+      'const k = "MCP_SERVER" + "_URL"; process.env[k];', // the one it cannot catch
+    ];
+    const caught = bypasses.map((src) => src.includes('MCP_SERVER_URL'));
+    expect(caught).toEqual([true, true, true, false]);
   });
 });

--- a/src/http/auth-challenge.test.ts
+++ b/src/http/auth-challenge.test.ts
@@ -132,3 +132,20 @@ describe('sendUnauthorized', () => {
     expect(order).toEqual(['header', 'body']);
   });
 });
+
+describe('normaliseBaseUrl', () => {
+  it('strips trailing slashes so no consumer has to', async () => {
+    // Guarding the two consumers I first noticed left eight others — the AS
+    // metadata, the OAuth callback registered with the platform, the
+    // project-selection redirect, two authorize URLs in error bodies, the
+    // projects URL and the banner. Express matches none of those routes with
+    // a doubled slash.
+    const { normaliseBaseUrl } = await import('./config.js');
+
+    expect(normaliseBaseUrl('https://mcp.insforge.dev/')).toBe('https://mcp.insforge.dev');
+    expect(normaliseBaseUrl('https://mcp.insforge.dev///')).toBe('https://mcp.insforge.dev');
+    expect(normaliseBaseUrl('https://mcp.insforge.dev')).toBe('https://mcp.insforge.dev');
+    // A path-bearing base keeps its path, loses only the trailing slash.
+    expect(normaliseBaseUrl('https://host/base/')).toBe('https://host/base');
+  });
+});

--- a/src/http/config.ts
+++ b/src/http/config.ts
@@ -23,6 +23,21 @@ const cliOptions = program.opts();
 // Server Configuration
 // ============================================================================
 
+/**
+ * A base URL with any trailing slash removed.
+ *
+ * Exported and applied once at the source rather than at each consumer,
+ * because there are ten of them — the AS metadata, the OAuth callback we
+ * register with the platform, the project-selection redirect, two authorize
+ * URLs in error bodies, the projects URL and the startup banner. A configured
+ * MCP_SERVER_URL ending in / gave every one a doubled slash, and Express
+ * matches none of those routes. Guarding the two I first noticed left the
+ * other eight, and left the next consumer free to reintroduce it.
+ */
+export function normaliseBaseUrl(url: string): string {
+  return url.replace(/\/+$/, '');
+}
+
 export const SERVER_CONFIG = {
   /**
    * Port to run HTTP server on.
@@ -44,7 +59,7 @@ export const SERVER_CONFIG = {
   host: cliOptions.host || '127.0.0.1',
 
   /** Public URL of this MCP server */
-  publicUrl: process.env.MCP_SERVER_URL || 'http://localhost:3000',
+  publicUrl: normaliseBaseUrl(process.env.MCP_SERVER_URL || 'http://localhost:3000'),
 } as const;
 
 // ============================================================================


### PR DESCRIPTION
## Why this is a separate PR

These two commits were on `fix/oauth-www-authenticate`, but **PR #69 merged at
head `ae0e438` — two commits behind the branch**, so they are not on `master`:

```
origin/fix/oauth-www-authenticate  a7dc73e
#69 merged at                      ae0e438
missing:  d29b115  Normalise publicUrl at the source, not at two consumers
          a7dc73e  Assert on the advertised URLs, and forbid the bypass
```

Confirmed against `master`: `normaliseBaseUrl` is absent, and
`publicUrl: process.env.MCP_SERVER_URL || 'http://localhost:3000'` is unguarded.

## What breaks without it

A configured `MCP_SERVER_URL` ending in `/` gives a doubled slash to every URL
we advertise, and Express matches none of those routes. There are ten
consumers; four are functional (Quinn's narrowing) and each breaks the login at
a different step: the AS metadata document, the OAuth callback we register with
the platform, the project-selection redirect, and the authorize links in 401
bodies. It fails silently — the client discards the metadata per RFC 9728 §3.3
rather than reporting a mismatch.

This matters right now because `MCP_SERVER_URL` is being set on Manufact by
hand for `https://mcp.insforge.dev`, and a trailing slash there is one keystroke.

## The fix

Normalise once where `publicUrl` is defined, so every consumer is safe by
construction — not per-consumer patching, which had already missed two of the
four.

## Tests

- `normaliseBaseUrl` unit test — covers the config-level fix. **Verified by
  mutation:** neutering `normaliseBaseUrl` to `return url` fails it
  (`1 failed | 18 passed`), restoring it passes.
- Three assertions over the *advertised* URLs given a slashed public URL
  (protected-resource documents, derived metadata URL, `resource_metadata` in
  the challenge). Doubled slashes are checked after the scheme so `https://` is
  not a false hit.
- A guard forbidding any file outside `config.ts` from reading
  `process.env.MCP_SERVER_URL` — the only remaining way to reintroduce this.

**Honest coverage note:** the three advertised-URL tests pass a slashed base
explicitly, so they exercise `origin()` in `auth-challenge.ts`, not the config
normalisation. The config fix is covered by the `normaliseBaseUrl` test and the
bypass guard. Stating that rather than letting three green tests imply it.

74 tests pass on this branch.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Normalizes the server `publicUrl` at the source by stripping trailing slashes from `MCP_SERVER_URL`, preventing `//` in advertised URLs and fixing silent login failures (AS metadata, OAuth callback, redirects, authorize links).

- **Bug Fixes**
  - Added `normaliseBaseUrl()` and applied it to `SERVER_CONFIG.publicUrl` in `src/http/config.ts`.
  - Tests assert no doubled slashes in advertised URLs (protected-resource docs, derived metadata URL, `WWW-Authenticate` challenge).
  - Strengthened guard: only `config.ts` may mention `MCP_SERVER_URL` (catches dot, bracket, and destructuring forms; anchored file walk; asserts it scans real files).

<sup>Written for commit e54c08d96a8f14d9946487ad41bbc1150af4eb9e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/insforge-mcp/pull/81?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

