### PR TITLE
Wire signed client ids into /oauth/register and /oauth/authorize

### DIFF
--- a/src/http/client-id.test.ts
+++ b/src/http/client-id.test.ts
@@ -3,7 +3,9 @@ import {
   mintClientId,
   readClientId,
   isRegisteredRedirectUri,
+  isAcceptableRedirectUri,
   InvalidClientIdError,
+  InvalidRegistrationError,
 } from './client-id.js';
 
 const SECRET = 'test-signing-secret';
@@ -122,5 +124,116 @@ describe('a missing secret is never silently substituted', () => {
   it('exports no secret generator', async () => {
     const mod = await import('./client-id.js');
     expect(Object.keys(mod)).not.toContain('generateSigningSecret');
+  });
+});
+
+describe('minting refuses what reading would reject', () => {
+  // john-bot's review of the unwired module: mintClientId validated nothing
+  // while readClientId enforced a shape, so mint could issue an id that could
+  // never be read back. Harmless while nothing called mint; the moment
+  // /oauth/register passes req.body straight in, it stops being harmless.
+  it('rejects an empty or absent redirect_uris', () => {
+    for (const bad of [[], undefined, null, 'https://app.example/cb', {}]) {
+      expect(() =>
+        mintClientId({ redirect_uris: bad as unknown as string[] }, SECRET)
+      ).toThrow(InvalidRegistrationError);
+    }
+  });
+
+  it('caps how many redirect_uris a registration may carry', () => {
+    // The payload is the client id and the client id is in every authorize
+    // URL, so an unbounded registration is an unbounded URL — and the failure
+    // would land on the redirect, not here where it can be explained.
+    const many = Array.from({ length: 11 }, (_, i) => `https://app.example/cb${i}`);
+    expect(() => mintClientId({ redirect_uris: many }, SECRET)).toThrow(InvalidRegistrationError);
+    expect(() => mintClientId({ redirect_uris: many.slice(0, 10) }, SECRET)).not.toThrow();
+  });
+
+  it('caps client_name', () => {
+    expect(() =>
+      mintClientId({ redirect_uris: [CALLBACK], client_name: 'x'.repeat(257) }, SECRET)
+    ).toThrow(InvalidRegistrationError);
+  });
+
+  it('carries only the fields we mean to sign', () => {
+    // req.body reaches this function. A spread would put every extra key the
+    // caller sent into the id.
+    const id = mintClientId(
+      {
+        redirect_uris: [CALLBACK],
+        client_name: 'Claude Code',
+        junk: 'x'.repeat(4096),
+      } as unknown as { redirect_uris: string[]; client_name: string },
+      SECRET
+    );
+    expect(readClientId(id, SECRET)).toEqual({
+      redirect_uris: [CALLBACK],
+      client_name: 'Claude Code',
+      iat: expect.any(Number),
+    });
+    expect(id).not.toContain('junk');
+  });
+
+  it('round-trips a registration with no client_name', () => {
+    const id = mintClientId({ redirect_uris: [CALLBACK] }, SECRET);
+    const reg = readClientId(id, SECRET);
+    expect(reg.client_name).toBeUndefined();
+    expect(reg.redirect_uris).toEqual([CALLBACK]);
+  });
+});
+
+describe('isAcceptableRedirectUri', () => {
+  // /oauth/authorize redirects to whatever the registration names, so the mint
+  // boundary is the place to keep dangerous values out entirely.
+  it('accepts https anywhere', () => {
+    expect(isAcceptableRedirectUri('https://app.example/cb')).toBe(true);
+  });
+
+  it('accepts plaintext http only on loopback', () => {
+    expect(isAcceptableRedirectUri('http://127.0.0.1:8765/callback')).toBe(true);
+    expect(isAcceptableRedirectUri('http://localhost:8765/callback')).toBe(true);
+    // An authorization code over plaintext http to a remote host is the code
+    // read off the wire.
+    expect(isAcceptableRedirectUri('http://app.example/cb')).toBe(false);
+    expect(isAcceptableRedirectUri('http://127.0.0.1.attacker.test/cb')).toBe(false);
+  });
+
+  it('accepts the private-use schemes real clients actually send', () => {
+    // RFC 8252 §7.1 asks for a reversed-domain scheme; shipped MCP clients do
+    // not comply, and an allowlist would reject them. Rejecting a working
+    // client to enforce a SHOULD is the wrong trade here.
+    for (const uri of [
+      'cursor://anysphere.cursor-retrieval/oauth/callback',
+      'vscode://insforge.mcp/callback',
+      'com.example.app:/oauth2redirect',
+    ]) {
+      expect(isAcceptableRedirectUri(uri)).toBe(true);
+    }
+  });
+
+  it('rejects script-capable and opaque schemes', () => {
+    for (const uri of [
+      'javascript:alert(1)',
+      'JavaScript:alert(1)',
+      'data:text/html,<script>alert(1)</script>',
+      'vbscript:msgbox(1)',
+      'file:///etc/passwd',
+      'blob:https://app.example/uuid',
+    ]) {
+      expect(isAcceptableRedirectUri(uri)).toBe(false);
+    }
+  });
+
+  it('rejects relative and unparseable values', () => {
+    // A relative URI would resolve against our own origin at redirect time.
+    for (const uri of ['/callback', 'callback', '', '://nope', 'https://' + 'a'.repeat(3000)]) {
+      expect(isAcceptableRedirectUri(uri)).toBe(false);
+    }
+  });
+
+  it('rejects non-strings', () => {
+    for (const bad of [undefined, null, 42, ['https://app.example/cb'], {}]) {
+      expect(isAcceptableRedirectUri(bad)).toBe(false);
+    }
   });
 });

--- a/src/http/client-id.test.ts
+++ b/src/http/client-id.test.ts
@@ -5,6 +5,7 @@ import {
   readClientId,
   isRegisteredRedirectUri,
   isAcceptableRedirectUri,
+  FORBIDDEN_SCHEMES,
   InvalidClientIdError,
   InvalidRegistrationError,
 } from './client-id.js';
@@ -220,17 +221,55 @@ describe('isAcceptableRedirectUri', () => {
     }
   });
 
-  it('rejects script-capable and opaque schemes', () => {
+  it('rejects every scheme on the denylist, derived from the denylist', () => {
+    // This test used to be named for a class and assert five enumerated
+    // values, so adding a sixth scheme to the set left it uncovered while the
+    // name still promised the class. Derived from FORBIDDEN_SCHEMES now, so a
+    // scheme cannot be added to the set without being tested.
+    expect(FORBIDDEN_SCHEMES.size).toBeGreaterThan(0);
+    for (const scheme of FORBIDDEN_SCHEMES) {
+      expect(isAcceptableRedirectUri(`${scheme}whatever`), scheme).toBe(false);
+    }
+  });
+
+  it('rejects them however the scheme is cased', () => {
+    // RFC 3986 §3.1 — and URL normalisation is what makes the set lookup work.
+    for (const uri of ['JavaScript:alert(1)', 'DATA:text/html,x', 'File:///etc/passwd']) {
+      expect(isAcceptableRedirectUri(uri)).toBe(false);
+    }
+  });
+
+  it('rejects them in the shapes an attacker would actually write', () => {
+    // The derived test above proves the set is enforced; these pin the real
+    // payloads, which is a different claim.
     for (const uri of [
       'javascript:alert(1)',
-      'JavaScript:alert(1)',
       'data:text/html,<script>alert(1)</script>',
       'vbscript:msgbox(1)',
       'file:///etc/passwd',
       'blob:https://app.example/uuid',
+      'about:blank',
     ]) {
       expect(isAcceptableRedirectUri(uri)).toBe(false);
     }
+  });
+
+  it('matches the reference platform on the wrapper schemes, and diverges on one', () => {
+    // A reviewer proposed a structural rule for these six. Measured against the
+    // platform whose filter we match 12 for 12: it accepts five of them and
+    // rejects about:. Adopting the structural rule would have made us stricter
+    // than the thing we chose to copy — and this is the exact filter being
+    // ported to the platform, so a narrowing here propagates there.
+    for (const uri of [
+      'view-source:https://attacker.test/',
+      'jar:https://attacker.test/!/a',
+      'filesystem:https://attacker.test/temporary/a',
+      'intent://attacker.test/#Intent;scheme=https;end',
+      'chrome://settings',
+    ]) {
+      expect(isAcceptableRedirectUri(uri), uri).toBe(true);
+    }
+    expect(isAcceptableRedirectUri('about:blank')).toBe(false);
   });
 
   it('rejects relative and unparseable values', () => {

--- a/src/http/client-id.test.ts
+++ b/src/http/client-id.test.ts
@@ -96,10 +96,18 @@ describe('redirect_uri matching', () => {
       'http://127.0.0.1:8765',
       'https://app.example/cb?next=https://attacker.example',
       'https://app.example.attacker.test/cb',
-      'HTTP://127.0.0.1:8765/callback',
     ]) {
       expect(isRegisteredRedirectUri(reg, near)).toBe(false);
     }
+  });
+
+  it('treats the scheme as case-insensitive, because it is', () => {
+    // This used to be asserted as a near-miss and rejected, which was an
+    // artifact of comparing strings rather than URLs. RFC 3986 §3.1 makes the
+    // scheme case-insensitive, the destination is byte-identical, and the
+    // platform's matchRedirectUri normalises the same way. Changed deliberately
+    // when loopback matching started parsing instead of comparing text.
+    expect(isRegisteredRedirectUri(reg, 'HTTP://127.0.0.1:8765/callback')).toBe(true);
   });
 
   it('rejects non-strings', () => {
@@ -298,5 +306,79 @@ describe('the id itself is bounded, not just its parts', () => {
     const longId = `mcp_${payload}.${sig}`;
     expect(longId.length).toBeGreaterThan(4096);
     expect(readClientId(longId, SECRET).redirect_uris).toHaveLength(1);
+  });
+});
+
+describe('loopback redirect_uris ignore the port (RFC 8252 §7.3)', () => {
+  // Max found the same bug in the platform's matchRedirectUri, where it had
+  // been flattened to includes() and would have broken `insforge login` — the
+  // CLI binds server.listen(0, '127.0.0.1'), so its port differs every run.
+  // The MCP had it too: a native MCP client registers on an ephemeral port,
+  // and the SDK re-registers only when it holds no client information at all,
+  // never in response to an authorize-time rejection. So an exact match hands
+  // the user the re-add page on every restart with nothing they can do.
+  const reg = (uri: string) => readClientId(mintClientId({ redirect_uris: [uri] }, SECRET), SECRET);
+
+  it('accepts a different port on the same loopback callback', () => {
+    const r = reg('http://127.0.0.1:54321/callback');
+    expect(isRegisteredRedirectUri(r, 'http://127.0.0.1:54321/callback')).toBe(true);
+    expect(isRegisteredRedirectUri(r, 'http://127.0.0.1:61999/callback')).toBe(true);
+    expect(isRegisteredRedirectUri(r, 'http://127.0.0.1/callback')).toBe(true);
+  });
+
+  it('still requires everything except the port to match', () => {
+    const r = reg('http://127.0.0.1:54321/callback');
+    for (const near of [
+      'http://127.0.0.1:61999/evil',            // different path
+      'http://127.0.0.1:61999/callback/../x',   // path traversal
+      'http://127.0.0.1:61999/callback?next=1', // query appears
+      'https://127.0.0.1:61999/callback',       // different scheme
+      'http://[::1]:61999/callback',            // different loopback family
+    ]) {
+      expect(isRegisteredRedirectUri(r, near)).toBe(false);
+    }
+  });
+
+  it('does not extend the relaxation to localhost', () => {
+    // RFC 8252 §8.3: localhost resolves through DNS and the hosts file, so it
+    // can be pointed off the loopback interface. The platform draws the line
+    // in the same place.
+    const named = reg('http://localhost:54321/callback');
+    expect(isRegisteredRedirectUri(named, 'http://localhost:54321/callback')).toBe(true);
+    expect(isRegisteredRedirectUri(named, 'http://localhost:61999/callback')).toBe(false);
+
+    const literal = reg('http://127.0.0.1:54321/callback');
+    expect(isRegisteredRedirectUri(literal, 'http://localhost:54321/callback')).toBe(false);
+  });
+
+  it('does not extend the relaxation to anything routable', () => {
+    const r = reg('https://app.example:8443/cb');
+    expect(isRegisteredRedirectUri(r, 'https://app.example:8443/cb')).toBe(true);
+    // A port-flexible match on a public host would let anyone with a service
+    // on another port of that host collect the code.
+    expect(isRegisteredRedirectUri(r, 'https://app.example:9999/cb')).toBe(false);
+    expect(isRegisteredRedirectUri(r, 'https://app.example/cb')).toBe(false);
+  });
+
+  it('preserves exact match for the custom schemes clients send', () => {
+    const r = reg('cursor://anysphere.cursor-retrieval/oauth/callback');
+    expect(isRegisteredRedirectUri(r, 'cursor://anysphere.cursor-retrieval/oauth/callback')).toBe(true);
+    expect(isRegisteredRedirectUri(r, 'cursor://anysphere.cursor-retrieval/oauth/evil')).toBe(false);
+  });
+
+  it('matches the platform on the same inputs', () => {
+    // Two servers, one dialect. Divergence here is a client that works against
+    // one and not the other, which is the hardest kind of bug to see.
+    const r = reg('http://127.0.0.1:8765/callback');
+    const platformSays: Array<[string, boolean]> = [
+      ['http://127.0.0.1:8765/callback', true],
+      ['http://127.0.0.1:1/callback', true],
+      ['http://127.0.0.1:8765/other', false],
+      ['http://localhost:8765/callback', false],
+      ['https://127.0.0.1:8765/callback', false],
+    ];
+    for (const [uri, expected] of platformSays) {
+      expect(isRegisteredRedirectUri(r, uri), uri).toBe(expected);
+    }
   });
 });

--- a/src/http/client-id.test.ts
+++ b/src/http/client-id.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from 'vitest';
+import { createHmac } from 'crypto';
 import {
   mintClientId,
   readClientId,
@@ -235,5 +236,67 @@ describe('isAcceptableRedirectUri', () => {
     for (const bad of [undefined, null, 42, ['https://app.example/cb'], {}]) {
       expect(isAcceptableRedirectUri(bad)).toBe(false);
     }
+  });
+});
+
+describe('the id itself is bounded, not just its parts', () => {
+  // Max's P1 on the wiring PR: every field was bounded and their product was
+  // not. 10 x 2048 plus a 256-char name is legal under all three per-field
+  // bounds and mints a 27807-character id — which registers 201 and then comes
+  // back 431 from authorize. The comment above the constants described that
+  // exact failure while the constants permitted it.
+  const maxUris = Array.from(
+    { length: 10 },
+    (_, i) => `https://app.example/${i}${'c'.repeat(2027)}`
+  );
+
+  it('rejects a registration whose per-field bounds all pass', () => {
+    for (const uri of maxUris) {
+      expect(isAcceptableRedirectUri(uri)).toBe(true); // each field is legal
+    }
+    expect(() =>
+      mintClientId({ redirect_uris: maxUris, client_name: 'x'.repeat(256) }, SECRET)
+    ).toThrow(InvalidRegistrationError);
+  });
+
+  it('says how big it was, so the client can act on it', () => {
+    expect(() => mintClientId({ redirect_uris: maxUris }, SECRET)).toThrow(/27\d{3}-character/);
+  });
+
+  it('still mints what real clients send', () => {
+    // Realistic is 198 characters; a generous four-URI registration is 1586.
+    const realistic = mintClientId(
+      { redirect_uris: ['cursor://anysphere.cursor-retrieval/oauth/callback'], client_name: 'Cursor' },
+      SECRET
+    );
+    expect(realistic.length).toBeLessThan(500);
+
+    const generous = mintClientId(
+      {
+        redirect_uris: Array.from({ length: 4 }, (_, i) => `https://app.example/${i}${'c'.repeat(235)}`),
+        client_name: 'x'.repeat(64),
+      },
+      SECRET
+    );
+    expect(generous.length).toBeLessThan(4096);
+  });
+
+  it('does not enforce the bound on read, so tightening it later is safe', () => {
+    // readClientId must never re-check this. If it did, lowering the limit
+    // would invalidate every id already issued at the old one — the failure
+    // mode that made the 30-day registration TTL so expensive.
+    const oversized = 'a'.repeat(5000);
+    const id = mintClientId({ redirect_uris: ['https://app.example/cb'] }, SECRET);
+    expect(id.length).toBeLessThan(4096);
+    expect(oversized.length).toBeGreaterThan(4096);
+
+    // Hand-build an id longer than the mint bound and prove it still reads.
+    const payload = Buffer.from(
+      JSON.stringify({ redirect_uris: [`https://app.example/${'c'.repeat(4000)}`], iat: 1 })
+    ).toString('base64url');
+    const sig = createHmac('sha256', SECRET).update(payload).digest('base64url');
+    const longId = `mcp_${payload}.${sig}`;
+    expect(longId.length).toBeGreaterThan(4096);
+    expect(readClientId(longId, SECRET).redirect_uris).toHaveLength(1);
   });
 });

--- a/src/http/client-id.test.ts
+++ b/src/http/client-id.test.ts
@@ -102,13 +102,25 @@ describe('redirect_uri matching', () => {
     }
   });
 
-  it('treats the scheme as case-insensitive, because it is', () => {
-    // This used to be asserted as a near-miss and rejected, which was an
-    // artifact of comparing strings rather than URLs. RFC 3986 §3.1 makes the
-    // scheme case-insensitive, the destination is byte-identical, and the
-    // platform's matchRedirectUri normalises the same way. Changed deliberately
-    // when loopback matching started parsing instead of comparing text.
+  it('is case-insensitive about the scheme ON LOOPBACK ONLY, exactly like the platform', () => {
+    // My first version of this test claimed scheme case-insensitivity as a
+    // general property — "because it is", RFC 3986 §3.1. That overclaimed:
+    // normalisation only happens on the loopback branch, because that is the
+    // only branch that parses instead of comparing text.
+    //
+    // The right fix is to narrow the claim, NOT to widen the code. The
+    // platform's matchRedirectUri is byte-exact for non-loopback too
+    // (insforge-cloud-backend src/utils/oauth.ts:412), so parsing everything
+    // would make us diverge from the server we are deliberately mirroring.
+    // Pinned in both directions so neither drifts silently.
     expect(isRegisteredRedirectUri(reg, 'HTTP://127.0.0.1:8765/callback')).toBe(true);
+
+    const routable = readClientId(
+      mintClientId({ redirect_uris: ['https://app.example/cb'] }, SECRET),
+      SECRET
+    );
+    expect(isRegisteredRedirectUri(routable, 'https://app.example/cb')).toBe(true);
+    expect(isRegisteredRedirectUri(routable, 'HTTPS://app.example/cb')).toBe(false);
   });
 
   it('rejects non-strings', () => {

--- a/src/http/client-id.ts
+++ b/src/http/client-id.ts
@@ -262,16 +262,71 @@ export function readClientId(clientId: string, secret: string): ClientRegistrati
 }
 
 /**
+ * A loopback IP literal, per RFC 8252 §7.3.
+ *
+ * `localhost` is deliberately excluded. §8.3 says a native client should use
+ * the IP literal precisely because `localhost` resolves through DNS and the
+ * hosts file, so it can be pointed somewhere that is not the loopback
+ * interface. The platform's `matchRedirectUri` draws the line in the same
+ * place, and the two servers agreeing is worth more here than the extra
+ * leniency would be.
+ */
+function isLoopbackIpLiteral(hostname: string): boolean {
+  return hostname === '127.0.0.1' || hostname === '::1' || hostname === '[::1]';
+}
+
+/**
  * Is this redirect_uri one the client registered?
  *
- * Exact string match, per RFC 6749 §3.1.2.3. No prefix or origin matching:
- * those are the relaxations that turn a redirect_uri check into an open
- * redirect, and an open redirect on an authorization endpoint is
- * authorization-code theft.
+ * Exact string match, per RFC 6749 §3.1.2.3 — with the one relaxation RFC 8252
+ * §7.3 requires and no others. No prefix matching and no origin matching: those
+ * are what turn a redirect_uri check into an open redirect, and an open
+ * redirect on an authorization endpoint is authorization-code theft.
+ *
+ * The exception is loopback. A native client binds an ephemeral port, so the
+ * port it registers is not the port it will be listening on next time, and an
+ * exact match rejects it. Concretely: register on 127.0.0.1:54321, restart,
+ * bind 61999, and the MCP SDK sends the cached client_id with the new port —
+ * it re-registers only when it holds no client information at all
+ * (`client/auth.js:226`), and never in response to an authorize-time rejection.
+ * So the user gets the re-add page on every restart, with nothing they can do
+ * about it.
+ *
+ * For loopback IP literals the port is ignored and scheme, hostname, path and
+ * query must all still match exactly. Everything else keeps exact match,
+ * including the port. This mirrors the platform's `matchRedirectUri`
+ * (`src/utils/oauth.ts:386`) rather than inventing a second dialect —
+ * flattening that function to `includes()` is what would have broken
+ * `insforge login`, whose CLI binds `server.listen(0, '127.0.0.1')`.
  */
 export function isRegisteredRedirectUri(
   registration: ClientRegistration,
   redirectUri: unknown
 ): boolean {
-  return typeof redirectUri === 'string' && registration.redirect_uris.includes(redirectUri);
+  if (typeof redirectUri !== 'string') return false;
+  if (registration.redirect_uris.includes(redirectUri)) return true;
+
+  let requested: URL;
+  try {
+    requested = new URL(redirectUri);
+  } catch {
+    return false;
+  }
+  if (!isLoopbackIpLiteral(requested.hostname)) return false;
+
+  return registration.redirect_uris.some((registered) => {
+    let candidate: URL;
+    try {
+      candidate = new URL(registered);
+    } catch {
+      return false;
+    }
+    return (
+      isLoopbackIpLiteral(candidate.hostname) &&
+      candidate.protocol === requested.protocol &&
+      candidate.hostname === requested.hostname &&
+      candidate.pathname === requested.pathname &&
+      candidate.search === requested.search
+    );
+  });
 }

--- a/src/http/client-id.ts
+++ b/src/http/client-id.ts
@@ -56,6 +56,30 @@ const MAX_URI_LENGTH = 2048;
 const MAX_CLIENT_NAME_LENGTH = 256;
 
 /**
+ * And a bound on the id itself, which is the only one of these that is actually
+ * about the URL.
+ *
+ * The per-field bounds above never constrained their product: 10 x 2048 plus a
+ * 256-character name is a legal registration under every one of them, and it
+ * mints a 27807-character client id. Measured, not reasoned about — that
+ * registration returns 201 and the authorize request it produces is 29944
+ * characters and comes back 431 Request Header Fields Too Large. Node's default
+ * max-http-header-size is 16384 and the request line counts toward it; nginx in
+ * front cuts the request line at 8192. So the comment above described this
+ * exact failure and the constants permitted it.
+ *
+ * 4096 is chosen from the same arithmetic rather than by feel: the worst
+ * authorize request line is this id plus an encoded redirect_uri plus about 150
+ * characters of other parameters, so 4096 stays inside the 8192 that fails
+ * first, with room. A realistic registration mints 198.
+ *
+ * Checked at mint only, deliberately. `readClientId` does not re-check it, so
+ * tightening this number later cannot invalidate ids already issued — the
+ * failure mode that made the 30-day TTL so expensive.
+ */
+const MAX_CLIENT_ID_LENGTH = 4096;
+
+/**
  * Schemes we will not carry in a registration.
  *
  * The authorize endpoint redirects to whatever the registration names, so this
@@ -166,7 +190,22 @@ export function mintClientId(
     iat: now,
   };
   const payload = Buffer.from(JSON.stringify(full)).toString('base64url');
-  return `${PREFIX}${payload}.${sign(payload, secret)}`;
+  const clientId = `${PREFIX}${payload}.${sign(payload, secret)}`;
+
+  // Measure the thing that actually travels. One check on the finished id
+  // cannot drift out of sync with the per-field bounds the way a fourth
+  // per-field bound would, and it is the only one whose units match the limit
+  // that fails — bytes on a request line.
+  if (clientId.length > MAX_CLIENT_ID_LENGTH) {
+    throw new InvalidRegistrationError(
+      `this registration mints a ${clientId.length}-character client_id, over the ` +
+        `${MAX_CLIENT_ID_LENGTH} limit. The client_id travels in every authorize URL, ` +
+        'so an oversized one is rejected by the server or a proxy before it is read. ' +
+        'Register fewer or shorter redirect_uris.'
+    );
+  }
+
+  return clientId;
 }
 
 /**

--- a/src/http/client-id.ts
+++ b/src/http/client-id.ts
@@ -32,7 +32,108 @@ export interface ClientRegistration {
 
 export class InvalidClientIdError extends Error {}
 
+/**
+ * A registration we refuse to mint. Separate from InvalidClientIdError because
+ * the two mean different things to a caller: this one is the client's fault at
+ * registration time (RFC 7591 `invalid_client_metadata`, 400), the other is an
+ * id that does not verify at authorize time.
+ */
+export class InvalidRegistrationError extends Error {}
+
 const PREFIX = 'mcp_';
+
+/**
+ * Bounds on what a registration may contain.
+ *
+ * The payload IS the client id, and the client id travels in every authorize
+ * URL, so an unbounded registration is an unbounded URL. Browsers and proxies
+ * cut those off well before Node does, and the failure would land on the
+ * authorize redirect rather than on registration where it could be explained.
+ * These are far above what any real client sends.
+ */
+const MAX_REDIRECT_URIS = 10;
+const MAX_URI_LENGTH = 2048;
+const MAX_CLIENT_NAME_LENGTH = 256;
+
+/**
+ * Schemes we will not carry in a registration.
+ *
+ * The authorize endpoint redirects to whatever the registration names, so this
+ * is the one place to keep script-capable and opaque schemes out. Browsers
+ * already refuse to navigate to `javascript:` or `data:` in a Location header,
+ * so this is defence in depth rather than the only guard.
+ *
+ * Deliberately a denylist and not an allowlist. RFC 8252 §7.1 says a native
+ * client should use a reversed-domain private-use scheme (`com.example.app:`),
+ * and real MCP clients simply do not — `cursor://`, `vscode://` and friends are
+ * what actually arrives. An allowlist of https + loopback http + dotted schemes
+ * is the more principled rule and it would reject working clients today, which
+ * is the failure this whole module exists to stop happening silently.
+ */
+const FORBIDDEN_SCHEMES = new Set(['javascript:', 'data:', 'vbscript:', 'file:', 'blob:']);
+
+/**
+ * Is this a redirect_uri we are willing to sign?
+ *
+ * Absolute (a relative URI would resolve against our own origin), not
+ * script-capable, and plaintext http only for loopback — per RFC 8252 §8.3 a
+ * native client redirects to 127.0.0.1, but anything else on http would carry
+ * an authorization code in the clear.
+ */
+export function isAcceptableRedirectUri(value: unknown): value is string {
+  if (typeof value !== 'string' || value.length === 0 || value.length > MAX_URI_LENGTH) {
+    return false;
+  }
+
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch {
+    return false; // not absolute, or not parseable at all
+  }
+
+  if (FORBIDDEN_SCHEMES.has(url.protocol)) {
+    return false;
+  }
+
+  if (url.protocol === 'http:') {
+    return url.hostname === 'localhost' || url.hostname === '127.0.0.1' || url.hostname === '[::1]';
+  }
+
+  return true;
+}
+
+/**
+ * Reject a registration we could sign but should not.
+ *
+ * `readClientId` already refuses a structurally wrong payload, so without this
+ * `mintClientId` would happily issue an id that can never be read back — the
+ * error surfacing at authorize time, in a browser, rather than at registration
+ * where the client is listening and the message can say what to fix.
+ */
+function assertMintable(registration: Omit<ClientRegistration, 'iat'>): void {
+  const { redirect_uris: uris, client_name: name } = registration;
+
+  if (!Array.isArray(uris) || uris.length === 0) {
+    throw new InvalidRegistrationError('redirect_uris is required and must be a non-empty array');
+  }
+  if (uris.length > MAX_REDIRECT_URIS) {
+    throw new InvalidRegistrationError(`redirect_uris must contain at most ${MAX_REDIRECT_URIS} entries`);
+  }
+  for (const uri of uris) {
+    if (!isAcceptableRedirectUri(uri)) {
+      throw new InvalidRegistrationError(
+        'each redirect_uri must be an absolute http(s) or application URI; ' +
+          'plaintext http is accepted only for loopback'
+      );
+    }
+  }
+  if (name !== undefined && (typeof name !== 'string' || name.length > MAX_CLIENT_NAME_LENGTH)) {
+    throw new InvalidRegistrationError(
+      `client_name must be a string of at most ${MAX_CLIENT_NAME_LENGTH} characters`
+    );
+  }
+}
 
 function sign(payload: string, secret: string): string {
   return createHmac('sha256', secret).update(payload).digest('base64url');
@@ -55,7 +156,15 @@ export function mintClientId(
   if (!secret) {
     throw new Error('a signing secret is required to mint client ids');
   }
-  const full: ClientRegistration = { ...registration, iat: now };
+  assertMintable(registration);
+  // Fields listed rather than spread. `registration` comes from a request body
+  // once this is wired, and a spread would carry every extra key the caller
+  // sent into the payload — which is the client id, which is the URL.
+  const full: ClientRegistration = {
+    redirect_uris: registration.redirect_uris,
+    ...(registration.client_name !== undefined ? { client_name: registration.client_name } : {}),
+    iat: now,
+  };
   const payload = Buffer.from(JSON.stringify(full)).toString('base64url');
   return `${PREFIX}${payload}.${sign(payload, secret)}`;
 }

--- a/src/http/client-id.ts
+++ b/src/http/client-id.ts
@@ -93,8 +93,31 @@ const MAX_CLIENT_ID_LENGTH = 4096;
  * what actually arrives. An allowlist of https + loopback http + dotted schemes
  * is the more principled rule and it would reject working clients today, which
  * is the failure this whole module exists to stop happening silently.
+ *
+ * The membership is set by measurement, not by taste. A reviewer proposed a
+ * structural rule instead — reject anything whose scheme is not http(s) and
+ * does not look like a private-use scheme. Running that rule against the six
+ * examples it was offered for closed three of them and left `intent://`,
+ * `chrome://` and `about:blank` accepted, while reading as though it had closed
+ * all six. Probing the same six against the platform whose filter we match 12
+ * for 12 found it accepts five of them. Adopting the structural rule would have
+ * made us stricter than the thing we chose to copy, for the same reason we did
+ * not copy an allowlist: principled rules reject `cursor://`.
+ *
+ * `about:` is the one value where we genuinely diverged, so it is here.
+ *
+ * Exported so a test can assert the property over every member rather than
+ * over a hand-copied list — a test named for a class that checks five
+ * instances stops covering the sixth the moment one is added.
  */
-const FORBIDDEN_SCHEMES = new Set(['javascript:', 'data:', 'vbscript:', 'file:', 'blob:']);
+export const FORBIDDEN_SCHEMES: ReadonlySet<string> = new Set([
+  'javascript:',
+  'data:',
+  'vbscript:',
+  'file:',
+  'blob:',
+  'about:',
+]);
 
 /**
  * Is this a redirect_uri we are willing to sign?

--- a/src/http/config.ts
+++ b/src/http/config.ts
@@ -1,4 +1,5 @@
 import 'dotenv/config';
+import { createHmac } from 'crypto';
 import { program } from 'commander';
 import { PACKAGE_VERSION } from '../shared/version.js';
 
@@ -88,6 +89,47 @@ export const OAUTH_CONFIG = {
   /** Code challenge methods supported (only S256 for security) */
   codeChallengesMethods: ['S256'],
 } as const;
+
+// ============================================================================
+// Client ID Signing Key
+// ============================================================================
+
+/**
+ * The key that signs client ids, derived rather than configured.
+ *
+ * No new environment variable: there are three, and a fourth that only this
+ * one feature needs would have to be generated, distributed and rotated by
+ * hand, and a server that booted without it would fail at the first
+ * registration rather than at boot.
+ *
+ * Derived from INSFORGE_CLIENT_SECRET through an HMAC with a fixed label, so
+ * the platform secret itself is never the signing key. That separation matters:
+ * a client id is public (it travels in every authorize URL), so its signatures
+ * are public samples of whatever key produced them. Deriving means those
+ * samples are of a key that can do nothing but sign client ids.
+ *
+ * Rotating INSFORGE_CLIENT_SECRET invalidates every client id, which is the
+ * intended and only revocation mechanism — see client-id.ts.
+ */
+const CLIENT_ID_KEY_LABEL = 'mcp-client-id-v1';
+
+export function deriveClientIdSigningKey(clientSecret: string): string {
+  if (!clientSecret) {
+    throw new Error(
+      'INSFORGE_CLIENT_SECRET is required: the client id signing key is derived from it'
+    );
+  }
+  return createHmac('sha256', clientSecret).update(CLIENT_ID_KEY_LABEL).digest('base64url');
+}
+
+/**
+ * Read lazily rather than at module load: config is imported by tests and by
+ * the stdio entry point, neither of which has platform credentials, and a
+ * throw at import time would take both down for a feature they never use.
+ */
+export function clientIdSigningKey(): string {
+  return deriveClientIdSigningKey(INSFORGE_CONFIG.clientSecret);
+}
 
 // ============================================================================
 // Redis Configuration

--- a/src/http/server.ts
+++ b/src/http/server.ts
@@ -24,11 +24,20 @@ import {
   isOAuthConfigured,
   isAnalyticsConfigured,
   validateConfig,
+  clientIdSigningKey,
 } from './config.js';
 import { renderProjectSelectionPage } from './templates/project-selection.js';
 import { renderOAuthErrorPage } from './templates/oauth-error.js';
 import { getAnalyticsService, extractClientInfo } from './analytics.js';
 import { sendUnauthorized, protectedResourceMetadata } from './auth-challenge.js';
+import {
+  mintClientId,
+  readClientId,
+  isRegisteredRedirectUri,
+  InvalidClientIdError,
+  InvalidRegistrationError,
+  type ClientRegistration,
+} from './client-id.js';
 import { statusForHttpError } from './error-status.js';
 import { PACKAGE_VERSION } from '../shared/version.js';
 
@@ -84,17 +93,6 @@ function isInitializeRequest(body: unknown): boolean {
 
   return false;
 }
-
-/**
- * How long a client registration survives without being used.
- *
- * Refreshed on every successful authorize (see below), so this is an idle
- * timeout rather than a hard lifetime. It used to be neither: the value was
- * written once at registration and never touched again, so every client
- * stopped working exactly 30 days after it registered no matter how heavily
- * it was being used.
- */
-const CLIENT_REGISTRATION_TTL = 30 * 24 * 60 * 60;
 
 /**
  * Whether this request is a browser navigation rather than a program's fetch.
@@ -246,7 +244,7 @@ app.get(OAUTH_ENDPOINTS.protectedResource, (_req: Request, res: Response) => {
 /**
  * OAuth Dynamic Client Registration (RFC 7591)
  */
-app.post(OAUTH_ENDPOINTS.register, async (req: Request, res: Response) => {
+app.post(OAUTH_ENDPOINTS.register, (req: Request, res: Response) => {
   const {
     client_name,
     redirect_uris,
@@ -256,43 +254,43 @@ app.post(OAUTH_ENDPOINTS.register, async (req: Request, res: Response) => {
     scope,
   } = req.body;
 
-  if (!redirect_uris || !Array.isArray(redirect_uris) || redirect_uris.length === 0) {
-    return res.status(400).json({
-      error: 'invalid_client_metadata',
-      error_description: 'redirect_uris is required and must be a non-empty array',
+  const clientName = typeof client_name === 'string' && client_name ? client_name : 'MCP Client';
+
+  // The registration is carried by the id itself, so nothing is written here.
+  // mintClientId validates redirect_uris — count, absoluteness, scheme, and
+  // loopback-only plaintext http — and rejects anything it would not be able to
+  // read back, which is why this route no longer pre-checks the array itself.
+  let clientId: string;
+  try {
+    clientId = mintClientId(
+      { redirect_uris, client_name: clientName },
+      clientIdSigningKey()
+    );
+  } catch (error) {
+    if (error instanceof InvalidRegistrationError) {
+      return res.status(400).json({
+        error: 'invalid_client_metadata',
+        error_description: error.message,
+      });
+    }
+    // A missing signing key is our misconfiguration, not the client's.
+    console.error('[OAuth] Could not mint a client id:', error);
+    return res.status(500).json({
+      error: 'server_error',
+      error_description: 'Client registration is not available on this server.',
     });
   }
 
-  const clientId = `mcp_${randomUUID().replace(/-/g, '')}`;
+  console.log(`[OAuth] Registered new client (${clientName})`);
 
-  const redis = getRedisClient();
-  const clientData = {
+  res.status(201).json({
     client_id: clientId,
-    client_name: client_name || 'MCP Client',
+    client_name: clientName,
     redirect_uris,
     grant_types: grant_types || OAUTH_CONFIG.grantTypes,
     response_types: response_types || ['code'],
     token_endpoint_auth_method: token_endpoint_auth_method || 'none',
     scope: scope || 'mcp:read mcp:write',
-    created_at: Date.now(),
-  };
-
-  await redis.setex(
-    `mcp:oauth:client:${clientId}`,
-    CLIENT_REGISTRATION_TTL,
-    JSON.stringify(clientData)
-  );
-
-  console.log(`[OAuth] Registered new client: ${clientId} (${clientData.client_name})`);
-
-  res.status(201).json({
-    client_id: clientId,
-    client_name: clientData.client_name,
-    redirect_uris: clientData.redirect_uris,
-    grant_types: clientData.grant_types,
-    response_types: clientData.response_types,
-    token_endpoint_auth_method: clientData.token_endpoint_auth_method,
-    scope: clientData.scope,
   });
 });
 
@@ -327,16 +325,31 @@ app.get(OAUTH_ENDPOINTS.authorize, async (req: Request, res: Response) => {
     });
   }
 
-  // Validate client_id and redirect_uri
-  const redis = getRedisClient();
-  const clientKey = `mcp:oauth:client:${client_id}`;
-  const clientDataStr = await redis.get(clientKey);
-  if (!clientDataStr) {
+  // Recover the registration from the id. The signature is what makes this
+  // trustworthy: anyone can read a client id, only this server can mint one, so
+  // a redirect_uri that verifies is one we approved at registration.
+  let registration: ClientRegistration;
+  try {
+    registration = readClientId(client_id as string, clientIdSigningKey());
+  } catch (error) {
+    if (!(error instanceof InvalidClientIdError)) {
+      // A missing or unreadable signing key — our problem, not the caller's,
+      // and it must not be reported as an unknown client.
+      console.error('[OAuth] Could not read client id:', error);
+      return res.status(500).json({
+        error: 'server_error',
+        error_description: 'Client registration is not available on this server.',
+      });
+    }
     // Nothing here can recover automatically. The MCP SDK only re-registers on
     // an invalid_client from the token endpoint or from registration, and it
     // never sees this response — the browser does. So the person holding the
     // tab is the only one who can act, and they need to be told how.
-    console.log(`[OAuth] Unknown client_id at authorize: ${client_id}`);
+    //
+    // This is also the path every client registered before this change takes:
+    // its id names a Redis row that is no longer read. The page below is the
+    // correct answer for them too — re-register and it works.
+    console.log('[OAuth] Client id at authorize did not verify');
     if (prefersHtml(req)) {
       return res.status(400).type('html').send(
         renderOAuthErrorPage({
@@ -355,51 +368,20 @@ app.get(OAUTH_ENDPOINTS.authorize, async (req: Request, res: Response) => {
     });
   }
 
-  let clientData: { client_id: string; redirect_uris: string[] };
-  try {
-    clientData = JSON.parse(clientDataStr);
-  } catch (parseError) {
-    console.error(`[OAuth] Failed to parse client data for client_id ${client_id}:`, parseError);
-    return res.status(500).json({
-      error: 'server_error',
-      error_description: 'Failed to read client registration data.',
-    });
-  }
-
-  // Validate required fields exist and have correct types
-  if (!clientData.client_id || typeof clientData.client_id !== 'string') {
-    console.error(`[OAuth] Invalid client data: missing or invalid client_id for ${client_id}`);
-    return res.status(500).json({
-      error: 'server_error',
-      error_description: 'Client registration data is corrupted.',
-    });
-  }
-
-  if (!Array.isArray(clientData.redirect_uris)) {
-    console.error(`[OAuth] Invalid client data: missing or invalid redirect_uris for ${client_id}`);
-    return res.status(500).json({
-      error: 'server_error',
-      error_description: 'Client registration data is corrupted.',
-    });
-  }
-
-  // Validate redirect_uri matches registered URIs
-  if (!clientData.redirect_uris.includes(redirect_uri as string)) {
+  // Exact match against what the client registered, per RFC 6749 §3.1.2.3.
+  // This is the check mcp-use's oauthProxy omits, and omitting it is
+  // authorization-code theft: the code would be delivered to whatever URI the
+  // request named.
+  if (!isRegisteredRedirectUri(registration, redirect_uri)) {
     return res.status(400).json({
       error: 'invalid_request',
       error_description: 'redirect_uri does not match any registered redirect URIs for this client.',
     });
   }
 
-  // The registration has been used successfully, so restart its idle clock.
-  // Without this the record expires on a fixed schedule from the moment it was
-  // written, taking working clients down with it. Failing to refresh must not
-  // fail the login — the worst case is the record expiring on its old schedule.
-  try {
-    await redis.expire(clientKey, CLIENT_REGISTRATION_TTL);
-  } catch (error) {
-    console.error(`[OAuth] Could not refresh registration TTL for ${client_id}:`, error);
-  }
+  // No TTL to refresh: the registration is not stored, so it cannot expire.
+  // The 30-day idle timeout this replaces is the bug that silently broke every
+  // client 30 days after it was installed.
 
   try {
     const oauthManager = getOAuthManager();

--- a/src/http/server.ts
+++ b/src/http/server.ts
@@ -281,7 +281,11 @@ app.post(OAUTH_ENDPOINTS.register, (req: Request, res: Response) => {
     });
   }
 
-  console.log(`[OAuth] Registered new client (${clientName})`);
+  // JSON.stringify, not interpolation: client_name is caller-supplied and only
+  // length-bounded, so a newline in it forges log lines — an attacker-chosen
+  // "[OAuth] ..." entry that reads exactly like ours. Quoting also makes
+  // trailing whitespace and empty names visible instead of silent.
+  console.log(`[OAuth] Registered new client (${JSON.stringify(clientName)})`);
 
   res.status(201).json({
     client_id: clientId,


### PR DESCRIPTION
Wires the module from #79. This is the commit that actually removes the Redis
client-registration row — #79 built the mechanism, this makes it the one in use.

## What changes

| | before | after |
|---|---|---|
| `/oauth/register` | `SETEX mcp:oauth:client:<uuid>` | mints a signed id, stores nothing |
| `/oauth/authorize` | `GET` the row, then `EXPIRE` to refresh a 30-day idle TTL | verifies the signature, reads the registration out of the id |
| registration lifetime | 30 days idle | none — nothing is stored, so nothing expires |

The signing key is **derived, not configured**: `HMAC(INSFORGE_CLIENT_SECRET,
"mcp-client-id-v1")`. No fourth environment variable. The platform secret is
never itself the signing key — a client id is public and travels in every
authorize URL, so its signatures are public samples of whatever key produced
them; deriving means those samples are of a key that can do nothing else.

## The four review notes from #79, landed here

Each was non-blocking on #79 *because nothing called the module*. Wiring is what
makes `req.body` reach `mintClientId`, so they stop being hypothetical:

1. **`mintClientId` validated nothing, `readClientId` enforced a shape** — mint
   could issue an id that could never be read back. Now rejected at registration,
   where the client is listening, instead of at authorize, in a browser.
2. **No `redirect_uri` scheme or absoluteness check.** `/oauth/authorize`
   redirects to whatever the registration names, so the mint boundary is the
   choke point. Rejects `javascript:` `data:` `vbscript:` `file:` `blob:`,
   requires absolute, and allows plaintext `http` only for loopback (RFC 8252
   §8.3) — an authorization code over plaintext http to a remote host is the
   code read off the wire.
3. **Unbounded registration.** The payload *is* the client id and the id is in
   every authorize URL, so `redirect_uris` (≤10) and `client_name` (≤256) are
   capped, and each URI is ≤2048.
4. **Fields listed rather than spread**, so extra keys in a request body cannot
   ride along into the id.

### One judgment call worth disagreeing with

The scheme rule is a **denylist, not an allowlist**, deliberately. RFC 8252 §7.1
says a native client should use a reversed-domain private-use scheme
(`com.example.app:`); real MCP clients send `cursor://` and `vscode://`. An
allowlist of https + loopback http + dotted schemes is the more principled rule
**and it would reject clients that work today** — which is exactly the silent
breakage this module exists to stop. Reasoning is in the code next to the
constant, so it can be revisited rather than rediscovered.

## Existing clients

A client registered before this deploys takes the `invalid_client` path — its id
names a row nothing reads any more. In a browser that is the re-add page from
#74, which is the correct answer for them: re-register and it works. Called out
in the code so it reads as intended rather than as an oversight.

## Verification

Unit tests cover the validation (136 in the suite). More importantly, **the
success path was executed against a running server**, because that is the part
that has bitten me before — failure paths are easy to exercise and prove nothing
about the path being claimed.

```
1 POST /oauth/register                                       201 + signed id
2 GET  /oauth/authorize  minted id + registered redirect_uri 302 -> platform
3 GET  /oauth/authorize  redirect_uri NOT registered         400 invalid_request
4 GET  /oauth/authorize  forged signature                    400 invalid_client
5 GET  /oauth/authorize  old Redis-era mcp_<uuid> id         400 invalid_client
5b    ... same with Accept: text/html                        400 + re-add page
6 POST /oauth/register   javascript:alert(1)                 400 invalid_client_metadata
7 POST /oauth/register   http://attacker.test/cb             400 invalid_client_metadata
8 POST /oauth/register   no redirect_uris                    400 invalid_client_metadata
9 POST /oauth/register   cursor://anysphere.../callback      201 (accepted)
```

And the claim that matters, measured rather than asserted — the complete Redis
command log for a register *and* an authorize:

```
CLIENT SETINFO / CLIENT SETINFO / INFO      connection setup
PING                                        startup check
SETEX mcp:auth:state:vjAs191c00Xh...        authorize's auth state
```

**No `mcp:oauth:client:` key appears at all** — not a write at register, not a
read or an EXPIRE at authorize. The auth state is the next slice.

Run against a stand-in RESP server rather than real Redis, since this box has
none; that is enough for "which keys were touched", which is the claim.

## Not in this PR

The startup `redis.ping()` still blocks boot without Redis, and the auth state,
codes, bindings and sessions still use it. This is 1 of the remaining 5.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make OAuth client registration stateless with signed client IDs, removing Redis and the 30‑day idle TTL. Tightens redirect URI rules and scopes scheme normalization to loopback only to match RFC 8252 and the platform.

- **New Features**
  - `/oauth/register` mints a signed `client_id`; `/oauth/authorize` verifies and reads the registration from it — nothing stored.
  - Signing key is derived: HMAC(`INSFORGE_CLIENT_SECRET`, `mcp-client-id-v1`) — no new env var.
  - Strict redirect URI validation: absolute, denylist `javascript:`/`data:`/`vbscript:`/`file:`/`blob:`/`about:`, and `http` only for loopback (`127.0.0.1`/`::1`/`[::1]`).
  - Matching: exact byte match, with loopback IP literals ignoring the port (not `localhost`); scheme case-insensitivity applies on loopback only.
  - Bounds: `redirect_uris` ≤10, each URI ≤2048, `client_name` ≤256, and the minted `client_id` ≤4096 (checked at mint only). Only intended fields are signed.
  - Logging and errors: escape `client_name` in logs; invalid registration → 400 `invalid_client_metadata`; unverifiable id → 400 `invalid_client` (HTML shows re‑add page); missing signing key → 500 `server_error`.

- **Migration**
  - Clients registered before this will hit `invalid_client` and see the re‑add page; re‑register to continue.

<sup>Written for commit 38602d2ae1f06fac5e904f36b60975408d9f8691. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/insforge-mcp/pull/82?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - OAuth client registrations now use signed client IDs, improving portability.
  - Added validation for redirect URIs, client names, registration size, and supported fields.
  - Authorization requires an exact match with a registered redirect URI.
  - Supports secure HTTPS, loopback HTTP, and approved private-use redirect schemes.

- **Bug Fixes**
  - Rejects invalid, unsafe, malformed, oversized, or unsupported redirect URIs.
  - Invalid client IDs and signing configuration errors now produce clearer failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->