### PR TITLE
Boot without Redis, and say so honestly

### DIFF
--- a/scripts/verify-deploy.mjs
+++ b/scripts/verify-deploy.mjs
@@ -125,14 +125,20 @@ check(
 
 // Runtime sessions should not run away from the ones Redis still holds. A
 // small excess is normal in-flight; an order of magnitude is the leak.
+// `activeSessions` is null when the server is running without Redis, which is
+// not a failure — there is simply no second number to compare against, and a
+// default of 0 would silently turn "unknown" into "zero active" and grade a
+// real leak against it.
 const sessions = health.body?.sessions;
-if (sessions) {
-  const { activeSessions: active = 0, memorySessionCount: resident = 0 } = sessions;
+if (sessions && typeof sessions.activeSessions === 'number') {
+  const { activeSessions: active, memorySessionCount: resident = 0 } = sessions;
   check(
     'resident sessions are not far above active ones',
     resident <= Math.max(active * 2, active + 50),
     `active=${active} resident=${resident}`
   );
+} else if (sessions) {
+  console.log('  ~ session ratio not checked: no Redis, so there is no active count');
 }
 
 // --- the 401 has to tell a client where to look ---------------------------
@@ -220,6 +226,24 @@ check(
   'the authorize endpoint is reachable and validating',
   authorize.status === 400,
   `status ${authorize.status}`
+);
+
+// The bare probe above stops at the missing-parameter check, which is BEFORE
+// the client lookup — so it passes on a server that cannot log anyone in. A
+// probe carrying parameters reaches the lookup, and an unknown client there is
+// a 400 `invalid_client`. A 500 means the lookup itself failed: no Redis, or
+// no signing key. This is the difference between "the routes exist" and "a
+// login could start", and everything else in this file only proves the former.
+const authorizeWithParams = await getJson(
+  '/oauth/authorize?client_id=verify-deploy-probe' +
+    '&redirect_uri=http%3A%2F%2F127.0.0.1%3A1%2Fcb&response_type=code'
+);
+check(
+  'the client lookup on /oauth/authorize works (a login could start)',
+  authorizeWithParams.status === 400,
+  authorizeWithParams.status === 500
+    ? 'status 500 — the client lookup failed; the remaining Redis uses are not gone yet'
+    : `status ${authorizeWithParams.status}`
 );
 
 // --- follow the chain to whichever AS the resources name -------------------

--- a/src/http/redis.test.ts
+++ b/src/http/redis.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { resolveRedisClientSpec, type RedisConfig } from './redis.js';
+import { resolveRedisClientSpec, isRedisConfigured, type RedisConfig } from './redis.js';
 
 /**
  * These exist because of a bug that was invisible: REDIS_PASSWORD was read into
@@ -104,5 +104,30 @@ describe('resolveRedisClientSpec — cluster', () => {
     expect(spec).toMatchObject({ nodes: [{ host: 'redis.internal', port: 6379 }] });
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     expect((spec.options as any).redisOptions.tls).toEqual({});
+  });
+});
+
+describe('isRedisConfigured', () => {
+  // The boot ping used to be unconditional, so a container with no Redis
+  // exited 1 before app.listen and nothing was reachable — not /health, not
+  // discovery, not a log line naming the cause. This predicate is what lets
+  // the server come up and say so instead.
+  it('is true when a URL or a host is given', () => {
+    expect(isRedisConfigured({ REDIS_URL: 'redis://cache:6379' })).toBe(true);
+    expect(isRedisConfigured({ REDIS_HOST: 'cache' })).toBe(true);
+  });
+
+  it('is false when nothing points anywhere', () => {
+    expect(isRedisConfigured({})).toBe(false);
+    expect(isRedisConfigured({ REDIS_URL: '', REDIS_HOST: '' })).toBe(false);
+  });
+
+  it('does not count a port, a password or TLS as a destination', () => {
+    // getRedisConfig defaults the host to localhost, so counting any of these
+    // would mean "configured" and send us straight back to a connection that
+    // can never succeed — the failure this exists to prevent.
+    expect(isRedisConfigured({ REDIS_PORT: '6379' })).toBe(false);
+    expect(isRedisConfigured({ REDIS_PASSWORD: 'hunter2' })).toBe(false);
+    expect(isRedisConfigured({ REDIS_TLS: 'true', REDIS_CLUSTER: 'true' })).toBe(false);
   });
 });

--- a/src/http/redis.ts
+++ b/src/http/redis.ts
@@ -49,6 +49,22 @@ export function getRedisConfig(): RedisConfig {
 }
 
 /**
+ * Has anyone actually pointed us at a Redis?
+ *
+ * `getRedisConfig` defaults the host to localhost, which is a sensible default
+ * for a developer and a lie in a container — nothing is listening there, so the
+ * server retried a connection that could never succeed and exited 1 before
+ * `app.listen`. That is what 19 Manufact deploys failed on after the missing
+ * start script was fixed.
+ *
+ * REDIS_PORT is deliberately not counted: a port with no host is not a
+ * destination, and treating it as one would put us straight back to localhost.
+ */
+export function isRedisConfigured(env: NodeJS.ProcessEnv = process.env): boolean {
+  return !!(env.REDIS_URL || env.REDIS_HOST);
+}
+
+/**
  * Resolve a config into the exact shape ioredis is constructed with.
  */
 export function resolveRedisClientSpec(config: RedisConfig): RedisClientSpec {

--- a/src/http/server.ts
+++ b/src/http/server.ts
@@ -9,7 +9,7 @@ import { SSEServerTransport } from '@modelcontextprotocol/sdk/server/sse.js';
 
 // Local imports
 import { getSessionManager } from './session-manager.js';
-import { getRedisClient, closeRedisClient, getRedisConfig } from './redis.js';
+import { getRedisClient, closeRedisClient, getRedisConfig, isRedisConfigured } from './redis.js';
 import { getOAuthManager } from './oauth-manager.js';
 import {
   SERVER_CONFIG,
@@ -1200,20 +1200,45 @@ async function startServer() {
     // Validate configuration
     validateConfig();
 
-    // Verify Redis connection
-    const redis = getRedisClient();
-    await redis.ping();
-    console.log('[Redis] Connection verified');
+    // Redis is on its way out of this server, and until the last use is gone a
+    // deploy without it should still boot. It used to exit 1 here, before
+    // app.listen, so nothing was reachable — not /health, not discovery, not
+    // even a log line naming the cause once the container had looped a few
+    // times. A server that answers and refuses to sign anyone in is far more
+    // diagnosable than one that is not there.
+    if (isRedisConfigured()) {
+      const redis = getRedisClient();
+      await redis.ping();
+      console.log('[Redis] Connection verified');
 
-    // Runtime sessions are only dropped on an explicit DELETE, which Streamable
-    // HTTP clients rarely send. Reap the ones Redis has already expired.
-    getSessionManager().startIdleSweep(SESSION_SWEEP_MS);
+      // Runtime sessions are only dropped on an explicit DELETE, which
+      // Streamable HTTP clients rarely send. Reap the ones Redis has already
+      // expired. Nothing to sweep when there is no Redis to expire them.
+      getSessionManager().startIdleSweep(SESSION_SWEEP_MS);
+    } else {
+      // Measured rather than assumed: with no Redis, /health and all four
+      // discovery documents answer 200 and POST /mcp gives its 401 challenge,
+      // which is everything needed to prove the edge routes us. /oauth/* still
+      // 500s — registration and auth state are the next slices — so the list
+      // below says so instead of promising a login that will not complete.
+      console.warn(
+        '[Redis] Not configured (no REDIS_URL or REDIS_HOST). ' +
+          'Serving /health, discovery and the 401 challenge; /oauth/* and every ' +
+          'session path will fail until the remaining Redis uses are removed.'
+      );
+    }
 
     const server = app.listen(SERVER_CONFIG.port, SERVER_CONFIG.host, () => {
       const redisConfig = getRedisConfig();
+      // The banner used to print "localhost:6379" whether or not anything was
+      // there, which is the same shape of lie as the REDIS_PASSWORD that looked
+      // configured and never reached ioredis. Print what is true.
+      const redisLine = isRedisConfigured()
+        ? `${redisConfig.host}:${redisConfig.port} (TLS: ${redisConfig.tls}, Cluster: ${redisConfig.cluster})`
+        : 'not configured — /oauth/* and sessions unavailable';
       console.log(`
 ╔═══════════════════════════════════════════════════════════════════════╗
-║           Insforge MCP Remote Server (OAuth + Redis)                  ║
+║              Insforge MCP Remote Server (OAuth)                       ║
 ╚═══════════════════════════════════════════════════════════════════════╝
 
 🚀 Server: http://${SERVER_CONFIG.host}:${SERVER_CONFIG.port}
@@ -1261,7 +1286,7 @@ async function startServer() {
    • Bind:       POST ${SERVER_CONFIG.publicUrl}${API_ENDPOINTS.bindProject}
 
 💾 Configuration:
-   • Redis:      ${redisConfig.host}:${redisConfig.port} (TLS: ${redisConfig.tls}, Cluster: ${redisConfig.cluster})
+   • Redis:      ${redisLine}
    • Insforge:   ${INSFORGE_CONFIG.apiBase}
    • Frontend:   ${INSFORGE_CONFIG.frontendUrl}
    • Analytics:  ${isAnalyticsConfigured() ? 'Mixpanel enabled' : 'Disabled (set MIXPANEL_TOKEN)'}

--- a/src/http/session-manager.ts
+++ b/src/http/session-manager.ts
@@ -1,7 +1,7 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
 import { SSEServerTransport } from '@modelcontextprotocol/sdk/server/sse.js';
-import { getRedisClient } from './redis.js';
+import { getRedisClient, isRedisConfigured } from './redis.js';
 import { SESSION_SWEEP_MS } from './config.js';
 import { registerInsforgeTools } from '../shared/tools/index.js';
 import { sdkToolHost } from '../shared/tools/host.js';
@@ -586,9 +586,16 @@ export class SessionManager {
    * Get session statistics
    */
   async getStats(): Promise<{
-    activeSessions: number;
+    activeSessions: number | null;
     memorySessionCount: number;
   }> {
+    // /health is the only caller, and it is what a deploy is graded on. Making
+    // it depend on Redis meant a server that was running and serving discovery
+    // still reported itself unhealthy — the reverse of what the check is for.
+    if (!isRedisConfigured()) {
+      return { activeSessions: null, memorySessionCount: this.runtimeSessions.size };
+    }
+
     const redis = getRedisClient();
 
     // Count sessions in Redis (using SCAN to avoid blocking)


### PR DESCRIPTION
Max's suggestion in-thread, and it is a strictly smaller change than the probe
branch it replaces: make the boot ping conditional so the real server boots on
Manufact today, and use it — rather than a throwaway probe — to answer whether
the edge routes `/oauth/*` and `/.well-known/*` or only `/mcp`.

## Why it never booted

`startServer()` pings Redis **before** `app.listen`. With no `REDIS_*` set the
promise rejects, the process exits 1, and nothing is reachable — not `/health`,
not discovery, not even a log line naming the cause once the container has
looped a few times. That is what every Manufact deploy since the start-script
fix has died on.

Redis is on its way out of this server anyway. Until the last use is gone, a
deploy without it should still come up: **a server that answers and refuses to
sign anyone in is far more diagnosable than one that is not there.**

## The predicate

```js
isRedisConfigured() === !!(REDIS_URL || REDIS_HOST)
```

Deliberately **not** `REDIS_PORT`, `REDIS_PASSWORD` or `REDIS_TLS`.
`getRedisConfig()` defaults the host to `localhost`, so counting any of those
would mean "configured" and send us straight back to a connection that can never
succeed. Tested explicitly.

## Three things that fell out, each found by running it

1. **`/health` needed Redis.** It calls `getStats()`, which `SCAN`s. So the one
   endpoint a deploy is graded on failed on a server that was up and serving
   every discovery document. `activeSessions` is now `null` when there is
   nothing to count.
2. **The banner printed `Redis: localhost:6379` whether or not anything was
   there** — the same shape of lie as the `REDIS_PASSWORD` that looked
   configured and never reached ioredis, which this repo already has a comment
   about.
3. **My first warning message claimed client registration works.** It does not
   on this branch — `/oauth/*` still 500s, because registration and auth state
   are the next slices. Corrected to say what is actually served. Reading the
   diff would not have caught that; running it did.

## verify-deploy gets the check that keeps this honest

Its bare `/oauth/authorize` probe stops at the missing-parameter check, which is
**before** the client lookup — so it scored **26/26 against a server that could
not log anyone in.** That is a false green on the exact gate we are about to
rely on.

A probe carrying parameters reaches the lookup. An unknown client there is a
`400 invalid_client`; a `500` means the lookup itself failed.

```
no Redis    FAIL  the client lookup on /oauth/authorize works (a login could start)
                  — status 500, the remaining Redis uses are not gone yet
            26/27, exit 1

with Redis  PASS  the client lookup on /oauth/authorize works
            28/28, exit 0
```

It discriminates, it fails today, it names why, and it turns green on its own
once the lookup no longer needs Redis. The session-ratio check is skipped rather
than defaulted to `0`, which would have turned "unknown" into "zero active" and
graded a real leak against it.

## Measured, with no Redis process anywhere

```
/health                                    200   sessions.activeSessions = null
/.well-known/oauth-authorization-server    200
/.well-known/oauth-protected-resource      200
/.well-known/oauth-protected-resource/mcp  200
/.well-known/oauth-protected-resource/sse  200
POST /mcp                                  401 + WWW-Authenticate resource_metadata
```

With Redis present nothing changes: ping runs, the sweep starts, the ratio is
checked, 28/28.

## What this does not do

Sign-in still will not complete — `/oauth/*` and every session path need the
remaining Redis uses removed (#82 is registration; auth state is next). This is
the change that makes Manufact **reachable and observable**, which is the step
that has been blocking everything else.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow the server to boot without Redis so deployments are reachable and diagnosable. Health, discovery, and `POST /mcp` work; `/oauth/*` and session routes remain unavailable when Redis isn’t configured.

- **Bug Fixes**
  - Make Redis ping and session sweep conditional via `isRedisConfigured()` (`REDIS_URL` or `REDIS_HOST` only).
  - `/health` no longer depends on Redis; returns `activeSessions: null` when absent.
  - Startup banner now shows Redis as “not configured — `/oauth/*` and sessions unavailable” instead of a misleading `localhost:6379`.
  - `scripts/verify-deploy.mjs`: add a parameterized `/oauth/authorize` probe to verify client lookup; skip the session ratio check when no Redis.

<sup>Written for commit 5f9d4e1497beb8cdf5f21e0066f90713ea98b3b8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/insforge-mcp/pull/83?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

