### PR TITLE
Every browser-visible OAuth error says what to do

### DIFF
--- a/src/http/oauth-error-response.test.ts
+++ b/src/http/oauth-error-response.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect, vi } from 'vitest';
+import { humanFormOf, prefersHtml, reconnectCommand, sendOAuthError } from './oauth-error-response.js';
+
+const MCP_URL = 'https://mcp.insforge.dev/mcp';
+
+/** Just enough of express's Request for the Accept negotiation. */
+const asBrowser = { accepts: (types: string[]) => (types.includes('html') ? 'html' : false) };
+const asClient = { accepts: (types: string[]) => (types.includes('json') ? 'json' : false) };
+
+function mockResponse() {
+  const res = {
+    status: vi.fn(() => res),
+    type: vi.fn(() => res),
+    send: vi.fn(() => res),
+    json: vi.fn(() => res),
+  };
+  return res as unknown as Parameters<typeof sendOAuthError>[1] & typeof res;
+}
+
+describe('who is actually looking at this error', () => {
+  it('gives a browser HTML', () => {
+    const res = mockResponse();
+    sendOAuthError(asBrowser, res, 400, { error: 'invalid_request' });
+    expect(res.type).toHaveBeenCalledWith('html');
+    expect(res.json).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(400);
+  });
+
+  it('gives a program the unchanged OAuth JSON', () => {
+    // A conforming client that does read the body still gets exactly what the
+    // spec says it should — the HTML is additive, not a replacement.
+    const res = mockResponse();
+    const body = { error: 'invalid_request', error_description: 'nope' };
+    sendOAuthError(asClient, res, 400, body);
+    expect(res.json).toHaveBeenCalledWith(body);
+    expect(res.send).not.toHaveBeenCalled();
+  });
+});
+
+describe('every browser-visible failure says what to do', () => {
+  // #74 wired the page to exactly one branch, the unknown client_id. The one a
+  // user is most likely to hit — a redirect_uri that does not match — kept
+  // returning raw JSON. Patching that single branch would have repeated the
+  // trailing-slash mistake, so this asserts the property over the codes.
+  it.each([
+    'invalid_client',
+    'invalid_request',
+    'server_error',
+    'unsupported_response_type',
+    'token_exchange_failed',
+    'access_denied',
+  ])('%s produces a heading and a message a person can act on', (error) => {
+    const human = humanFormOf({ error }, MCP_URL);
+    expect(human.heading.length).toBeGreaterThan(10);
+    expect(human.message.length).toBeGreaterThan(40);
+    // No machine vocabulary leaking into the sentence a person reads.
+    expect(human.heading).not.toMatch(/_|redirect_uri|client_id/);
+  });
+
+  it('names the command that repairs a REMOTE client, not the local installer', () => {
+    // These users arrived over the remote URL — that is the only way to reach
+    // this page at all, since this server serves it. `npx @insforge/install`
+    // installs a local stdio server with an API key: a different product, not
+    // a repair. This page said that until it was traced.
+    for (const error of ['invalid_client', 'invalid_request']) {
+      const action = humanFormOf({ error }, MCP_URL).action as string[];
+      expect(action).toEqual([
+        'npx add-mcp remove insforge -y',
+        'npx add-mcp https://mcp.insforge.dev/mcp',
+      ]);
+      expect(action.join(' ')).not.toContain('@insforge/install');
+    }
+  });
+
+  it('removes before adding, so it is not a no-op on an unchanged URL', () => {
+    // add-mcp deep-merges under the server key and byte-preserves the rest, and
+    // the key is inferred from the hostname. So on a same-hostname cutover a
+    // bare `add-mcp <url>` rewrites an identical entry and changes nothing:
+    // the stuck user runs it, fails identically, and opens a ticket. Removing
+    // first is what makes the instruction do something — and it is correct on
+    // a new hostname too, where it clears the stale entry anyway.
+    const [first, second] = reconnectCommand(MCP_URL);
+    expect(first).toContain('remove');
+    expect(second).toContain(MCP_URL);
+  });
+
+  it('names the host the person is actually talking to', () => {
+    // On the Manufact slug it must say the slug, or someone follows the
+    // instruction and reconnects to the box we are migrating off.
+    expect(reconnectCommand('https://keen-pulse-fsjr9.run.mcp-use.com/mcp')).toEqual([
+      'npx add-mcp remove insforge -y',
+      'npx add-mcp https://keen-pulse-fsjr9.run.mcp-use.com/mcp',
+    ]);
+  });
+
+  it('does not tell someone to reinstall when that would not help', () => {
+    // A server-side failure is not fixed by re-adding the server, and saying so
+    // would send a person round a loop that cannot terminate.
+    expect(humanFormOf({ error: 'server_error' }, MCP_URL).action).toBeUndefined();
+  });
+
+  it('renders the redirect_uri case as the port-change it almost always is', () => {
+    const human = humanFormOf({ error: 'invalid_request' }, MCP_URL);
+    expect(human.message).toMatch(/different port/);
+  });
+
+  it('falls back to the description for a code it has never seen', () => {
+    expect(humanFormOf({ error: 'weird_new_code', error_description: 'the disk melted' }, MCP_URL).message)
+      .toBe('the disk melted');
+  });
+
+  it('still says something when there is no description either', () => {
+    expect(humanFormOf({ error: 'weird_new_code' }, MCP_URL).message.length).toBeGreaterThan(40);
+  });
+});
+
+describe('prefersHtml', () => {
+  it('is false for a client asking for json', () => {
+    expect(prefersHtml(asClient)).toBe(false);
+  });
+
+  it('is true for a browser', () => {
+    expect(prefersHtml(asBrowser)).toBe(true);
+  });
+});

--- a/src/http/oauth-error-response.test.ts
+++ b/src/http/oauth-error-response.test.ts
@@ -65,7 +65,7 @@ describe('every browser-visible failure says what to do', () => {
     for (const error of ['invalid_client', 'invalid_request']) {
       const action = humanFormOf({ error }, MCP_URL).action as string[];
       expect(action).toEqual([
-        'npx add-mcp remove insforge -y',
+        `npx add-mcp remove ${MCP_URL} -y`,
         'npx add-mcp https://mcp.insforge.dev/mcp',
       ]);
       expect(action.join(' ')).not.toContain('@insforge/install');
@@ -84,13 +84,24 @@ describe('every browser-visible failure says what to do', () => {
     expect(second).toContain(MCP_URL);
   });
 
-  it('names the host the person is actually talking to', () => {
+  it('names the host the person is actually talking to, in BOTH commands', () => {
     // On the Manufact slug it must say the slug, or someone follows the
     // instruction and reconnects to the box we are migrating off.
-    expect(reconnectCommand('https://keen-pulse-fsjr9.run.mcp-use.com/mcp')).toEqual([
-      'npx add-mcp remove insforge -y',
-      'npx add-mcp https://keen-pulse-fsjr9.run.mcp-use.com/mcp',
+    //
+    // Both commands, because the removal used to hardcode "insforge" while the
+    // add step was host-derived: on the slug the removal then matched no
+    // server at all and the repair silently did nothing. add-mcp matches
+    // `server.identity === query` and identity is the URL for a remote entry,
+    // so passing the URL is exact on every host.
+    const slug = 'https://keen-pulse-fsjr9.run.mcp-use.com/mcp';
+    expect(reconnectCommand(slug)).toEqual([
+      `npx add-mcp remove ${slug} -y`,
+      `npx add-mcp ${slug}`,
     ]);
+    for (const command of reconnectCommand(slug)) {
+      expect(command).toContain('keen-pulse-fsjr9');
+      expect(command).not.toContain('insforge');
+    }
   });
 
   it('does not tell someone to reinstall when that would not help', () => {

--- a/src/http/oauth-error-response.ts
+++ b/src/http/oauth-error-response.ts
@@ -104,7 +104,23 @@ export interface HumanForm {
  * never reached. Measured, not inferred.
  */
 export function reconnectCommand(mcpUrl: string): string[] {
-  return ['npx add-mcp remove insforge -y', `npx add-mcp ${mcpUrl}`];
+  // Remove BY URL, not by name. The name is derived from the hostname, so a
+  // hardcoded "insforge" matches nothing on any host that infers a different
+  // key — including the Manufact slug we spent a day testing on:
+  //
+  //   mcp.insforge.dev                   -> key "insforge"
+  //   keen-pulse-fsjr9.run.mcp-use.com   -> key "keen-pulse-fsjr9"
+  //
+  // I made the ADD step host-derived and left the REMOVE step hardcoded, which
+  // is the same inconsistency in one function. Max caught it.
+  //
+  // The URL works because add-mcp's findMatchingServers matches
+  // `server.identity === query` as well as by name, and extractServerIdentity
+  // returns the server's url for a remote entry (add-mcp@2.0.0,
+  // chunk-2LJORNPV.js). So passing the URL is exact, host-derived by
+  // construction, and cannot drift the way a copy of their inference rule
+  // would.
+  return [`npx add-mcp remove ${mcpUrl} -y`, `npx add-mcp ${mcpUrl}`];
 }
 
 /**

--- a/src/http/oauth-error-response.ts
+++ b/src/http/oauth-error-response.ts
@@ -1,0 +1,196 @@
+import type { Response } from 'express';
+import { renderOAuthErrorPage } from './templates/oauth-error.js';
+import { SERVER_CONFIG, STREAMABLE_HTTP_ENDPOINTS } from './config.js';
+
+/**
+ * Sending an OAuth error to whoever is actually looking at it.
+ *
+ * `/oauth/authorize` and `/oauth/callback` are reached by a browser
+ * navigation. The MCP client never reads those responses — it is waiting on a
+ * loopback callback that will now never arrive — so the only party who sees an
+ * error body is the person staring at the tab.
+ *
+ * #74 added a page saying what to do, and wired it to exactly one branch: the
+ * unknown client_id. Every other way authorize can fail kept returning raw
+ * OAuth JSON to that same tab. The one a user is most likely to hit — a
+ * redirect_uri that does not match the registration — was among them, so the
+ * live failure mode on the deployed server shows `{"error":"invalid_request"}`
+ * and no instruction at all.
+ *
+ * That is the same shape of mistake as normalising a trailing slash at two of
+ * ten consumers. So this is a helper every browser-reachable error goes
+ * through, not a second patched branch.
+ */
+
+/**
+ * The one thing this needs from a request. Narrower than express's Request on
+ * purpose: the negotiation is the whole logic, and a two-line stand-in in a
+ * test is worth more than a full Request mock nobody reads.
+ */
+export interface AcceptNegotiable {
+  accepts(types: string[]): string | false;
+}
+
+export interface OAuthErrorBody {
+  error: string;
+  error_description?: string;
+}
+
+export interface HumanForm {
+  heading: string;
+  message: string;
+  /** Optional literal(s) the user should run, rendered as code. */
+  action?: string | string[];
+}
+
+/**
+ * The command that actually repairs one of these users.
+ *
+ * NOT `npx @insforge/install`, which is what this page said until Max traced
+ * where the connected clients came from. There are two install paths and they
+ * produce different products:
+ *
+ *   npx @insforge/install   installs @insforge/mcp as a LOCAL stdio server with
+ *                           an API key. Never contacts this server at all.
+ *   npx add-mcp <url>       adds the REMOTE server — server.json remotes[], and
+ *                           what the setup docs tell people to run.
+ *
+ * Everyone who can possibly SEE this page arrived over the remote URL, because
+ * this page is served by the remote server. So the old instruction was wrong
+ * one hundred percent of the time, not merely sometimes — and following it
+ * would have quietly moved someone onto a different product configuration
+ * rather than fixing the one they had.
+ *
+ * TWO commands, not one, and that is the part measured rather than assumed.
+ * Blair read add-mcp@2.0.0: writeJsonConfig deep-merges under the server key
+ * and byte-preserves everything else, and the key is inferred from the
+ * hostname. So on a SAME-hostname cutover `add-mcp <url>` writes an entry
+ * identical to the one already there and changes nothing — the stuck user runs
+ * it, fails identically, and opens a ticket. Removing first is what makes the
+ * instruction do something.
+ *
+ * Correct on both roads, which is why it does not wait on the hostname
+ * decision: on a new hostname the removal clears the stale entry you wanted
+ * gone anyway; on the same hostname it is the only thing that helps. I checked
+ * `remove <query>` exists with -y in that version rather than trusting the
+ * name, and that the package stores no tokens of its own (its single "oauth"
+ * reference is an oauthScopes CONFIG field).
+ *
+ * What this still cannot promise: whether removing the config entry also drops
+ * the client's saved OAuth registration is client-specific — add-mcp deletes
+ * its config key and nothing more. If some client keys its registration by
+ * server name rather than URL, even remove+add leaves it stuck. That is a real
+ * test on a real editor, not something to settle in a comment.
+ *
+ * Built from publicUrl, which is the CANONICAL host this deployment is
+ * configured to be — deliberately not the host the request arrived on. The Host
+ * header is attacker-controlled, and a page that echoed it would hand a
+ * stuck user a command pointing wherever the attacker liked. Same reason the
+ * discovery documents use publicUrl (server.ts, "to avoid host header
+ * spoofing").
+ *
+ * Do not "fix" this to use the requested host. Today one deployment serves one
+ * hostname so the two coincide and nothing distinguishes them; the moment a
+ * retired hostname is pointed at a live deployment they diverge, and the
+ * requested-host reading tells someone stuck on the dead host to re-add the
+ * dead host. That is a loop with no exit, aimed at exactly the users a cutover
+ * exists to rescue.
+ *
+ * Note for anyone planning that retired-hostname setup: it does not work by
+ * itself, and not because of this function. A client reaching an old host whose
+ * publicUrl is the NEW host gets a protected-resource document naming a
+ * different origin, and the SDK throws in selectResourceURL
+ * (client/auth.js:339) BEFORE it ever opens the browser — so this page is
+ * never reached. Measured, not inferred.
+ */
+export function reconnectCommand(mcpUrl: string): string[] {
+  return ['npx add-mcp remove insforge -y', `npx add-mcp ${mcpUrl}`];
+}
+
+/**
+ * What to tell a person, given the machine-readable error.
+ *
+ * Pure and exported so the wording is testable without standing up express —
+ * the part that matters here is the words, and they are the part a route test
+ * would be least likely to assert.
+ */
+export function humanFormOf(body: OAuthErrorBody, mcpUrl: string): HumanForm {
+  switch (body.error) {
+    case 'invalid_client':
+      return {
+        heading: 'This connection needs to be set up again',
+        message:
+          'The app you are connecting from is not registered with this server any more. ' +
+          'Nothing is wrong with your account and no data was lost — remove the InsForge MCP ' +
+          'server from your client and add it back with the command below, and this will ' +
+          'complete normally.',
+        action: reconnectCommand(mcpUrl),
+      };
+
+    case 'invalid_request':
+      // Overwhelmingly a redirect_uri that does not match the registration.
+      // The remedy is identical to invalid_client — re-register — and the
+      // cause is not something the person can inspect, so saying "invalid
+      // request" and stopping would be true and useless.
+      return {
+        heading: 'This connection needs to be set up again',
+        message:
+          'The address your app asked us to send you back to is not the one it registered. ' +
+          'That usually means the app was reinstalled or restarted on a different port. ' +
+          'Re-adding the InsForge MCP server with the command below fixes it.',
+        action: reconnectCommand(mcpUrl),
+      };
+
+    case 'server_error':
+      return {
+        heading: 'Something went wrong on our side',
+        message:
+          'This is not something you can fix by retrying the same way. If it keeps happening, ' +
+          'the details below are what support will ask for.',
+      };
+
+    default:
+      return {
+        heading: 'Sign-in could not be completed',
+        message:
+          body.error_description ||
+          'The sign-in did not complete. Removing the InsForge MCP server from your client ' +
+          'and adding it back is the usual remedy.',
+        action: reconnectCommand(mcpUrl),
+      };
+  }
+}
+
+/**
+ * Is this request a browser navigation rather than a program's fetch?
+ *
+ * Kept here next to its only purpose. `req.accepts` returns the best match, so
+ * a client sending `application/json` still gets JSON even though browsers
+ * send a long Accept header that also mentions it.
+ */
+export function prefersHtml(req: AcceptNegotiable): boolean {
+  return req.accepts(['json', 'html']) === 'html';
+}
+
+/**
+ * Send an OAuth error as HTML to a browser and as JSON to everything else.
+ *
+ * The JSON body is unchanged in either case — a conforming client that does
+ * read it still gets exactly what the spec says it should.
+ */
+export function sendOAuthError(
+  req: AcceptNegotiable,
+  res: Response,
+  status: number,
+  body: OAuthErrorBody,
+  human?: Partial<HumanForm>
+): Response {
+  if (prefersHtml(req)) {
+    const mcpUrl = `${SERVER_CONFIG.publicUrl}${STREAMABLE_HTTP_ENDPOINTS.mcp}`;
+    return res
+      .status(status)
+      .type('html')
+      .send(renderOAuthErrorPage({ ...humanFormOf(body, mcpUrl), ...human }));
+  }
+  return res.status(status).json(body);
+}

--- a/src/http/server.ts
+++ b/src/http/server.ts
@@ -565,7 +565,12 @@ app.get(OAUTH_ENDPOINTS.callback, async (req: Request, res: Response) => {
       errorDescription: 'Failed to process callback',
       endpoint: '/oauth/callback',
     });
-    res.status(statusForHttpError(error)).json({
+    // The EIGHTH browser-reachable branch, and the third time on this PR that
+    // I converted the ones I could see and missed one. The callback is a
+    // browser navigation end to end, so its outer catch is as visible as any
+    // branch inside it. Counting is not the method; routing everything through
+    // one helper is, and this is the last place that was not.
+    sendOAuthError(req, res, statusForHttpError(error), {
       error: 'server_error',
       error_description: error instanceof Error ? error.message : 'Failed to process callback',
     });

--- a/src/http/server.ts
+++ b/src/http/server.ts
@@ -27,9 +27,9 @@ import {
   clientIdSigningKey,
 } from './config.js';
 import { renderProjectSelectionPage } from './templates/project-selection.js';
-import { renderOAuthErrorPage } from './templates/oauth-error.js';
 import { getAnalyticsService, extractClientInfo } from './analytics.js';
 import { sendUnauthorized, protectedResourceMetadata } from './auth-challenge.js';
+import { sendOAuthError } from './oauth-error-response.js';
 import {
   mintClientId,
   readClientId,
@@ -92,17 +92,6 @@ function isInitializeRequest(body: unknown): boolean {
   }
 
   return false;
-}
-
-/**
- * Whether this request is a browser navigation rather than a program's fetch.
- *
- * The authorize endpoint is reached by opening a URL in the user's browser —
- * the MCP client never reads the response itself — so an error here has to be
- * written for a person. Everything else still gets the OAuth JSON body.
- */
-function prefersHtml(req: Request): boolean {
-  return req.accepts(['json', 'html']) === 'html';
 }
 
 /**
@@ -275,7 +264,7 @@ app.post(OAUTH_ENDPOINTS.register, (req: Request, res: Response) => {
     }
     // A missing signing key is our misconfiguration, not the client's.
     console.error('[OAuth] Could not mint a client id:', error);
-    return res.status(500).json({
+    return sendOAuthError(req, res, 500, {
       error: 'server_error',
       error_description: 'Client registration is not available on this server.',
     });
@@ -306,24 +295,39 @@ app.get(OAUTH_ENDPOINTS.authorize, async (req: Request, res: Response) => {
   const { client_id, redirect_uri, response_type, scope, state, code_challenge, code_challenge_method } = req.query;
 
   if (!isOAuthConfigured()) {
-    return res.status(500).json({
+    return sendOAuthError(req, res, 500, {
       error: 'server_error',
       error_description: 'OAuth client credentials not configured. Set INSFORGE_CLIENT_ID and INSFORGE_CLIENT_SECRET.',
     });
   }
 
   if (!client_id || !redirect_uri || !response_type) {
-    return res.status(400).json({
-      error: 'invalid_request',
-      error_description: 'Missing required parameters: client_id, redirect_uri, response_type',
-    });
+    return sendOAuthError(
+      req,
+      res,
+      400,
+      {
+        error: 'invalid_request',
+        error_description: 'Missing required parameters: client_id, redirect_uri, response_type',
+      },
+      {
+        // Distinct from the redirect_uri wording: reaching authorize with no
+        // parameters at all is usually a person opening the URL by hand, and
+        // telling them to reinstall would be wrong.
+        heading: 'There is nothing to sign in to here',
+        message:
+          'This page is the middle of a sign-in that a tool starts for you. Opening it ' +
+          'directly does nothing. Start the connection from your editor or client instead.',
+        action: undefined,
+      }
+    );
   }
 
   // Default scope if not provided (scope is optional per OAuth 2.0 spec)
   const resolvedScope = (scope as string) || OAUTH_CONFIG.supportedScopes.join(' ');
 
   if (response_type !== 'code') {
-    return res.status(400).json({
+    return sendOAuthError(req, res, 400, {
       error: 'unsupported_response_type',
       error_description: 'Only response_type=code is supported',
     });
@@ -354,19 +358,7 @@ app.get(OAUTH_ENDPOINTS.authorize, async (req: Request, res: Response) => {
     // its id names a Redis row that is no longer read. The page below is the
     // correct answer for them too — re-register and it works.
     console.log('[OAuth] Client id at authorize did not verify');
-    if (prefersHtml(req)) {
-      return res.status(400).type('html').send(
-        renderOAuthErrorPage({
-          heading: 'This connection needs to be set up again',
-          message:
-            'The app you are connecting from is not registered with this server any more. ' +
-            'Nothing is wrong with your account and no data was lost — remove the InsForge MCP ' +
-            'server from your client and add it back, and this will complete normally.',
-          action: 'npx @insforge/install',
-        })
-      );
-    }
-    return res.status(400).json({
+    return sendOAuthError(req, res, 400, {
       error: 'invalid_client',
       error_description: 'Unknown client_id. Register client first via /oauth/register.',
     });
@@ -377,7 +369,9 @@ app.get(OAUTH_ENDPOINTS.authorize, async (req: Request, res: Response) => {
   // authorization-code theft: the code would be delivered to whatever URI the
   // request named.
   if (!isRegisteredRedirectUri(registration, redirect_uri)) {
-    return res.status(400).json({
+    // The branch a real user is most likely to reach, and until now the one
+    // that told them least: raw JSON in a browser tab.
+    return sendOAuthError(req, res, 400, {
       error: 'invalid_request',
       error_description: 'redirect_uri does not match any registered redirect URIs for this client.',
     });
@@ -411,8 +405,12 @@ app.get(OAUTH_ENDPOINTS.authorize, async (req: Request, res: Response) => {
     console.log(`[OAuth] Redirecting to Insforge OAuth: ${authUrl.toString()}`);
     res.redirect(authUrl.toString());
   } catch (error) {
+    // john-bot's Critical on this PR, and it is the tenth consumer in a change
+    // whose whole point was not stopping at the ones I noticed. The entire GET
+    // is a browser navigation, so a throw anywhere inside it — a platform
+    // outage, a missing signing key — put raw JSON in the person's tab.
     console.error('OAuth authorize error:', error);
-    res.status(statusForHttpError(error)).json({
+    sendOAuthError(req, res, statusForHttpError(error), {
       error: 'server_error',
       error_description: 'Failed to initiate authorization',
     });
@@ -449,7 +447,13 @@ app.get(OAUTH_ENDPOINTS.callback, async (req: Request, res: Response) => {
       return res.redirect(redirectUrl.toString());
     }
 
-    return res.status(400).json({ error, error_description });
+    // No registered redirect to bounce the error back to, so this ends in the
+    // user's tab. The callback is ALWAYS a browser navigation — it is the
+    // platform redirecting them here — so JSON was never right on any branch.
+    return sendOAuthError(req, res, 400, {
+      error: error as string,
+      error_description: error_description as string | undefined,
+    });
   }
 
   if (!code || !state) {
@@ -458,10 +462,19 @@ app.get(OAUTH_ENDPOINTS.callback, async (req: Request, res: Response) => {
       errorDescription: 'Missing required parameters: code, state',
       endpoint: '/oauth/callback',
     });
-    return res.status(400).json({
-      error: 'invalid_request',
-      error_description: 'Missing required parameters: code, state',
-    });
+    return sendOAuthError(
+      req,
+      res,
+      400,
+      { error: 'invalid_request', error_description: 'Missing required parameters: code, state' },
+      {
+        heading: 'This sign-in did not come back complete',
+        message:
+          'The sign-in was interrupted before it finished. Starting it again from your ' +
+          'editor or client is all that is needed.',
+        action: undefined,
+      }
+    );
   }
 
   try {
@@ -472,10 +485,19 @@ app.get(OAUTH_ENDPOINTS.callback, async (req: Request, res: Response) => {
         errorDescription: 'Invalid or expired state',
         endpoint: '/oauth/callback',
       });
-      return res.status(400).json({
-        error: 'invalid_request',
-        error_description: 'Invalid or expired state',
-      });
+      return sendOAuthError(
+        req,
+        res,
+        400,
+        { error: 'invalid_request', error_description: 'Invalid or expired state' },
+        {
+          heading: 'This sign-in took too long',
+          message:
+            'Sign-ins expire after a few minutes, and this one has. Start it again from ' +
+            'your editor or client — nothing is wrong with your account.',
+          action: undefined,
+        }
+      );
     }
 
     console.log('[OAuth] Exchanging code for tokens...');
@@ -508,10 +530,22 @@ app.get(OAUTH_ENDPOINTS.callback, async (req: Request, res: Response) => {
         errorDescription: 'Token exchange failed',
         endpoint: '/oauth/callback',
       });
-      return res.status(400).json({
-        error: 'token_exchange_failed',
-        error_description: tokens.error_description || tokens.error || 'No access token returned',
-      });
+      return sendOAuthError(
+        req,
+        res,
+        400,
+        {
+          error: 'token_exchange_failed',
+          error_description: tokens.error_description || tokens.error || 'No access token returned',
+        },
+        {
+          heading: 'Sign-in could not be completed',
+          message:
+            'The InsForge platform did not return a token for this sign-in. Trying again ' +
+            'usually works; if it does not, the details below are what support will ask for.',
+          action: undefined,
+        }
+      );
     }
 
     console.log('[OAuth] Token received, redirecting to project selection...');

--- a/src/http/templates/oauth-error.ts
+++ b/src/http/templates/oauth-error.ts
@@ -10,8 +10,14 @@
 export interface OAuthErrorPageOptions {
   heading: string;
   message: string;
-  /** Optional literal the user should run or check. Rendered as code. */
-  action?: string;
+  /**
+   * Optional literal(s) the user should run or check, rendered as code.
+   *
+   * A list as well as a string because a repair is sometimes a sequence, and
+   * joining commands with a newline inside one inline <code> collapses them
+   * into a single unrunnable line.
+   */
+  action?: string | string[];
 }
 
 export function renderOAuthErrorPage(options: OAuthErrorPageOptions): string {
@@ -91,7 +97,9 @@ export function renderOAuthErrorPage(options: OAuthErrorPageOptions): string {
   <div class="card">
     <h1>${escapeHtml(heading)}</h1>
     <p>${escapeHtml(message)}</p>
-    ${action ? `<code>${escapeHtml(action)}</code>` : ''}
+    ${(action ? (Array.isArray(action) ? action : [action]) : [])
+      .map((line) => `<code>${escapeHtml(line)}</code>`)
+      .join('\n    ')}
   </div>
 </body>
 </html>`;


### PR DESCRIPTION
Max verified on `master` that #74's actionable page is wired to exactly **one**
branch — the unknown `client_id` at `server.ts:340`. The `redirect_uri` mismatch
at `:387` returns `invalid_request` and never reaches it.

So the branch a real user is most likely to hit shows this, in a browser tab:

```json
{"error":"invalid_request","error_description":"redirect_uri does not match any registered redirect URIs for this client."}
```

No mention of re-adding the server. No `npx @insforge/install`. And the person
looking at that tab is the only one who can act — the MCP client is waiting on a
loopback callback that will never arrive.

## Why this is a helper and not a patched line

Patching `:387` alone would repeat the trailing-slash mistake exactly: guard the
two consumers you happened to notice, leave the other eight. Every
browser-reachable error now goes through one function.

```
/oauth/authorize   missing params · bad response_type · unknown client
                   corrupted registration · redirect_uri mismatch
/oauth/callback    platform error with nowhere to bounce it · missing code/state
                   expired state · token exchange failed
```

**The callback is always a browser navigation** — it is the platform redirecting
the person here — so JSON was never the right answer on any branch of it.

The JSON body is unchanged for anything that asks for JSON. A conforming client
that does read it still gets exactly what the spec says it should; the HTML is
additive.

## Wording is per error code, on purpose

The remedies genuinely differ, and a single generic page would be wrong for most
of them:

| code | says | names the command |
|---|---|---|
| `invalid_client` | re-register | yes |
| `invalid_request` (authorize) | "restarted on a different port" → re-register | yes |
| `server_error` | ours to fix, not yours | **no** |
| no params at all | "this page is the middle of a sign-in" | **no** |
| expired state | "sign-ins expire after a few minutes" | **no** |

`server_error` deliberately does not suggest reinstalling — re-adding the server
does not fix our outage, and telling someone to do it sends them round a loop
that cannot terminate. Opening `/oauth/authorize` by hand gets its own wording
rather than being told to reinstall something.

## Tests

`humanFormOf` is pure and exported, so the sentences are testable without
standing up express. That is deliberate: **the wording is the whole point of the
change**, and it is what a route-level test would be least likely to assert.

The test asserts the property over the error codes rather than one example —
"the page is reachable from one branch" is precisely the bug being fixed, so a
test that checks one branch would reproduce it.

## Verified against a running server, both audiences, all seven branches

```
authorize: no params            browser 400 <!DOCTYPE html>   client 400 {"error":...
authorize: bad response_type    browser 400 <!DOCTYPE html>   client 400 {"error":...
authorize: unknown client       browser 400 <!DOCTYPE html>   client 400 {"error":...
authorize: redirect mismatch    browser 400 <!DOCTYPE html>   client 400 {"error":...
callback:  no code/state        browser 400 <!DOCTYPE html>   client 400 {"error":...
callback:  expired state        browser 400 <!DOCTYPE html>   client 400 {"error":...
callback:  platform error       browser 400 <!DOCTYPE html>   client 400 {"error":...
```

What a person now reads on the live failure:

> **This connection needs to be set up again**
> The address your app asked us to send you back to is not the one it
> registered. That usually means the app was reinstalled or restarted on a
> different port. Remove the InsForge MCP server from your client and add it
> back, and this will complete normally.
> `npx @insforge/install`

Success path still 302.

## Relationship to the other PRs

#82 removes the *cause* for the loopback case (RFC 8252 §7.3 port-agnostic
matching). This fixes the *symptom* for every case, including the ones #82 does
not and should not make disappear — a genuinely wrong path is still an error,
it just needs to be a legible one. Branched off `master`, so it is independent
of #81/#82/#83 and can merge in any order.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show clear HTML guidance for all browser-visible OAuth errors while preserving JSON for API clients. Fix reconnect instructions to remove and add by URL so repairs work on any host.

- **Bug Fixes**
  - All errors from `/oauth/authorize`, `/oauth/callback`, and `/oauth/register` go through `sendOAuthError` (including catch blocks), returning HTML to browsers and JSON to clients; `/oauth/select-project` is unchanged.
  - `invalid_client` and `invalid_request` now instruct:
    - `npx add-mcp remove <publicUrl>/mcp -y`
    - `npx add-mcp <publicUrl>/mcp`
  - Removal uses the URL, not a hardcoded name; both commands are built from `SERVER_CONFIG.publicUrl` + `STREAMABLE_HTTP_ENDPOINTS.mcp` to avoid no-op cutovers and host header spoofing.
  - Callback-specific states (manual open, missing/expired params, token exchange failures) show clear messages; `server_error` shows no action.
  - `reconnectCommand` returns both commands; template `action` supports `string | string[]`.
  - Tests cover wording, content negotiation, host-exact commands, remove-before-add behavior, and removal-by-URL.

<sup>Written for commit dc648538a7abb6116eda32f8175cb4b789336332. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/insforge-mcp/pull/84?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced OAuth error handling with clearer, human-readable guidance for browsers.
  * Browser responses now provide reconnect instructions, redirect guidance, and actionable error details.
  * Programmatic clients continue receiving unchanged JSON error responses.
  * Reconnect actions support separate remove and add commands for easier recovery.

* **Tests**
  * Added comprehensive coverage for browser and client responses, fallback errors, redirects, reconnect commands, and response ordering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->