### PR TITLE
fix(verify): probe authorize with a complete request, not a bare one

### DIFF
--- a/scripts/verify-deploy.mjs
+++ b/scripts/verify-deploy.mjs
@@ -222,6 +222,38 @@ check(
   `status ${authorize.status}`
 );
 
+// The two checks above are both satisfied by the argument-validation layer,
+// which answers before the handler touches its client store. That is exactly
+// how this script scored a PASS on a deployment where no user could log in:
+// registration and authorize were both 500ing on
+// `MaxRetriesPerRequestError (ioredis)`, and a parameterless probe never got
+// far enough to see it.
+//
+// So send a request that is complete enough to reach the store. The client id
+// is deliberately one that cannot exist: a server whose store is healthy looks
+// it up, misses, and says so; a server whose store is unreachable cannot get
+// that far. Both outcomes are 4xx-vs-5xx, and neither registers anything, so
+// the script stays read-only.
+//
+//   400 invalid_client -> store reached, id genuinely unknown  (healthy)
+//   500                -> the lookup itself failed             (broken)
+const probeAuthorize = await getJson(
+  '/oauth/authorize?response_type=code' +
+    '&client_id=verify-deploy-probe-not-a-real-client' +
+    '&redirect_uri=' + encodeURIComponent('http://127.0.0.1:33418/callback') +
+    '&code_challenge=E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM' +
+    '&code_challenge_method=S256' +
+    '&state=verify-deploy'
+);
+check(
+  'a fully-formed authorize request reaches the client store',
+  probeAuthorize.status !== 500,
+  probeAuthorize.status === 500
+    ? 'authorize 500s on a complete request — the client store is unreachable, ' +
+      'so no login can complete (check Redis/backing store)'
+    : `status ${probeAuthorize.status}`
+);
+
 // --- follow the chain to whichever AS the resources name -------------------
 // This is the client's next hop, so it gets checked whether the AS is us or the
 // platform. RFC 8414 §3.1 derives the URL the same way RFC 9728 does — insert


### PR DESCRIPTION
## Changes

`verify-deploy.mjs` scored **PASS** on a deployment where no user could log in. This adds the check that catches it.

## Why

Both existing authorize assertions are answered by the **argument-validation layer**, which runs before the handler touches its client store. A parameterless probe 400s on missing params and never reaches the dependency.

Live, on the Manufact slug (`keen-pulse-fsjr9.run.mcp-use.com`, master @ `d78a33d`, no Redis):

```
GET  /oauth/authorize            -> 400 invalid_request       "PASS the authorize endpoint is reachable and validating"
POST /oauth/register {}          -> 400 invalid_client_metadata
```
Textbook RFC 4xx — reads as healthy. But with a **valid** body:
```
POST /oauth/register {redirect_uris:[...], ...}   -> 500 MaxRetriesPerRequestError (ioredis)
GET  /oauth/authorize?<full params + PKCE>        -> 500 same
```

## The new check

Send a request complete enough to reach the store, with a client id that cannot exist:

```
400 invalid_client -> store reached, id genuinely unknown   (healthy)
500                -> the lookup itself failed              (broken)
```

Registers nothing, so the script keeps its read-only contract.

## Testing

Verified in both directions against live deployments:

| target | store | result |
|---|---|---|
| `keen-pulse-fsjr9.run.mcp-use.com` (no Redis) | broken | **FAIL** — 23/27 |
| `mcp.insforge.dev` (EC2, Redis-backed) | healthy | **PASS** — 16/25 |

## Backwards Compatibility

Not breaking. Adds one assertion; total count 26 -> 27.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes verify-deploy by sending a complete `/oauth/authorize` request so it actually hits the client store. Prevents false PASS results when the backing store (e.g., Redis) is down.

- **Bug Fixes**
  - Add full authorize probe (PKCE + fake client_id) to reach the store.
  - 400 invalid_client = store reachable (healthy); 500 = lookup failed (broken).
  - Read-only check; no registration or state changes.

<sup>Written for commit dab2eaec2eb53a9e293ef7d3f9b9fd60b1b43de0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/insforge-mcp/pull/85?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

