### PR TITLE
Authorization state as a sealed value, not a Redis row

### DIFF
--- a/src/http/auth-state.test.ts
+++ b/src/http/auth-state.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect } from 'vitest';
+import { createHmac } from 'crypto';
+import { sealAuthState, openAuthState, InvalidAuthStateError, AUTH_STATE_TTL_SECONDS } from './auth-state.js';
+import { deriveAuthStateKey, deriveClientIdSigningKey } from './config.js';
+
+const KEY = deriveAuthStateKey('a-platform-client-secret');
+const OTHER = deriveAuthStateKey('a-different-client-secret');
+
+const STATE = {
+  clientId: 'mcp_abc.def',
+  redirectUri: 'http://127.0.0.1:8765/callback',
+  scope: 'mcp:read mcp:write',
+  state: 'client-csrf-value',
+  codeChallenge: 'a'.repeat(43),
+  codeChallengeMethod: 'S256',
+  insforgeCodeVerifier: 'v'.repeat(43),
+  createdAt: 1785480000000,
+};
+
+describe('authorization state round-trips', () => {
+  it('returns exactly what was sealed', () => {
+    expect(openAuthState(sealAuthState(STATE, KEY), KEY)).toEqual(STATE);
+  });
+
+  it('produces a different blob every time for the same input', () => {
+    // A fresh nonce per seal. A repeated nonce under one key is how GCM fails
+    // catastrophically, so this is the property, not a nicety.
+    const a = sealAuthState(STATE, KEY);
+    const b = sealAuthState(STATE, KEY);
+    expect(a).not.toBe(b);
+    expect(openAuthState(a, KEY)).toEqual(openAuthState(b, KEY));
+  });
+});
+
+describe('the PKCE verifier is not readable from the sealed value', () => {
+  // This is the whole reason auth state is encrypted rather than signed, like
+  // client ids are. The state parameter travels through the platform and sits
+  // in the browser's address bar; a signed-but-readable envelope would publish
+  // the verifier to exactly the party PKCE defends against.
+  it('does not contain the verifier in any obvious encoding', () => {
+    const sealed = sealAuthState(STATE, KEY);
+    const body = sealed.slice('v1.'.length);
+    const decoded = Buffer.from(body, 'base64url').toString('binary');
+
+    for (const haystack of [sealed, decoded]) {
+      expect(haystack).not.toContain(STATE.insforgeCodeVerifier);
+      expect(haystack).not.toContain('insforgeCodeVerifier');
+    }
+    // ...nor the client's own redirect, which would make the blob a target list.
+    expect(sealed).not.toContain('127.0.0.1');
+  });
+});
+
+describe('a sealed state cannot be forged or altered', () => {
+  it('refuses another key', () => {
+    expect(() => openAuthState(sealAuthState(STATE, KEY), OTHER)).toThrow(InvalidAuthStateError);
+  });
+
+  it('refuses a key derived with the other label from the same secret', () => {
+    // Same environment variable, different purpose. If these collided, a public
+    // client id and a secret-bearing auth state would share a key.
+    const secret = 'one-secret-two-purposes';
+    const clientIdKey = Buffer.from(deriveClientIdSigningKey(secret), 'base64url');
+    expect(clientIdKey.length).toBe(32);
+    expect(clientIdKey.equals(deriveAuthStateKey(secret))).toBe(false);
+    expect(() => openAuthState(sealAuthState(STATE, deriveAuthStateKey(secret)), clientIdKey)).toThrow(
+      InvalidAuthStateError
+    );
+  });
+
+  it('refuses a single flipped byte anywhere in the blob', () => {
+    const sealed = sealAuthState(STATE, KEY);
+    const raw = Buffer.from(sealed.slice(3), 'base64url');
+    for (const i of [0, 6, 12, 20, raw.length - 1]) {
+      const tampered = Buffer.from(raw);
+      tampered[i] ^= 0x01;
+      expect(() => openAuthState(`v1.${tampered.toString('base64url')}`, KEY)).toThrow(
+        InvalidAuthStateError
+      );
+    }
+  });
+
+  it('refuses values that are not ours at all', () => {
+    for (const bad of ['', 'v1.', 'v1.notbase64!!', 'v2.abc', 'abc', 'v1.' + 'A'.repeat(20)]) {
+      expect(() => openAuthState(bad, KEY), bad).toThrow(InvalidAuthStateError);
+    }
+  });
+
+  it('refuses non-strings', () => {
+    for (const bad of [undefined, null, 42, {}]) {
+      expect(() => openAuthState(bad as unknown as string, KEY)).toThrow(InvalidAuthStateError);
+    }
+  });
+});
+
+describe('expiry travels inside the seal', () => {
+  const T0 = 1_700_000_000_000;
+
+  it('accepts up to the TTL and refuses after it', () => {
+    const sealed = sealAuthState(STATE, KEY, T0);
+    expect(openAuthState(sealed, KEY, T0)).toEqual(STATE);
+    expect(openAuthState(sealed, KEY, T0 + AUTH_STATE_TTL_SECONDS * 1000 - 1)).toEqual(STATE);
+    expect(() => openAuthState(sealed, KEY, T0 + AUTH_STATE_TTL_SECONDS * 1000)).toThrow(
+      InvalidAuthStateError
+    );
+  });
+
+  it('cannot have its expiry extended by whoever holds the blob', () => {
+    // exp is inside the ciphertext, so it is covered by the auth tag. If it sat
+    // beside the blob it could simply be rewritten.
+    const sealed = sealAuthState(STATE, KEY, T0);
+    const raw = Buffer.from(sealed.slice(3), 'base64url');
+    // Flip bytes across the ciphertext body; every attempt must be rejected
+    // rather than yielding a state with a later expiry.
+    for (let i = 28; i < Math.min(raw.length, 60); i += 7) {
+      const tampered = Buffer.from(raw);
+      tampered[i] ^= 0xff;
+      expect(() => openAuthState(`v1.${tampered.toString('base64url')}`, KEY, T0)).toThrow(
+        InvalidAuthStateError
+      );
+    }
+  });
+});
+
+describe(`a wrong key is our fault, not the caller's`, () => {
+  it('throws a plain Error, never InvalidAuthStateError', () => {
+    // Distinct on purpose: a misconfigured server must not report itself to a
+    // client as "your state is invalid", which is the mislabelling that sends
+    // someone to re-add a working install.
+    for (const bad of [Buffer.alloc(16), Buffer.alloc(0), 'not a buffer' as unknown as Buffer]) {
+      expect(() => sealAuthState(STATE, bad)).toThrow(Error);
+      expect(() => sealAuthState(STATE, bad)).not.toThrow(InvalidAuthStateError);
+    }
+  });
+});

--- a/src/http/auth-state.ts
+++ b/src/http/auth-state.ts
@@ -1,0 +1,137 @@
+import { createCipheriv, createDecipheriv, randomBytes } from 'crypto';
+
+/**
+ * Authorization state as a sealed value rather than a Redis row.
+ *
+ * `/oauth/authorize` writes a row keyed by a random id and hands that id to the
+ * platform as the `state` parameter; `/oauth/callback` reads the row back. That
+ * row is the next thing keeping Redis on the critical path, and like the client
+ * registration it is pure derived data — everything in it was known at the
+ * moment it was written.
+ *
+ * So carry it in the state parameter. The difference from client-id.ts is the
+ * one that decides the mechanism:
+ *
+ *   a client id is PUBLIC        -> signing is enough
+ *   auth state holds a SECRET    -> it has to be encrypted
+ *
+ * The secret is `insforgeCodeVerifier`, our PKCE verifier for the call to the
+ * platform. A signed-but-readable envelope would print it in the authorize URL,
+ * in the browser's address bar and in the platform's logs. PKCE exists to
+ * protect against exactly the party who can read that URL, so publishing the
+ * verifier there would remove the protection while leaving the ceremony.
+ *
+ * AES-256-GCM: confidentiality and integrity from one primitive, so there is no
+ * encrypt-then-MAC ordering to get wrong. The nonce is random per seal and
+ * carried alongside; a repeated nonce under one key is the way GCM fails
+ * catastrophically, and 96 random bits per authorization is far below any
+ * birthday concern for a value that lives ten minutes.
+ *
+ * SIZE, because this is the same trap one hop further along. The sealed state
+ * contains the client id, and the sealed state then travels in the PLATFORM's
+ * authorize URL — so a big registration inflates a request line we do not own.
+ * Measured against a running server rather than estimated:
+ *
+ *   realistic registration   client_id  171   platform authorize URL  1037
+ *   largest #82 accepts      client_id 3980   platform authorize URL  6494
+ *
+ * So MAX_CLIENT_ID_LENGTH (4096, chosen from the 8192 request-line limit) turns
+ * out to bound this hop too, with room. That is luck rather than design:
+ * anyone raising that constant has to re-measure THIS number, not only the one
+ * it was chosen for.
+ */
+
+export class InvalidAuthStateError extends Error {}
+
+/** How long a sealed state is accepted. Matches the Redis TTL it replaces. */
+export const AUTH_STATE_TTL_SECONDS = 10 * 60;
+
+const VERSION = 'v1';
+const NONCE_BYTES = 12; // 96 bits, the GCM standard
+const TAG_BYTES = 16;
+
+/**
+ * Seal a value so only this server can read it back.
+ *
+ * `expiresAt` travels INSIDE the sealed payload rather than beside it, so it is
+ * covered by the authentication tag and cannot be extended by an attacker who
+ * holds the blob.
+ */
+export function sealAuthState<T>(value: T, key: Buffer, nowMs: number = Date.now()): string {
+  assertKey(key);
+
+  const payload = JSON.stringify({
+    v: value,
+    exp: nowMs + AUTH_STATE_TTL_SECONDS * 1000,
+  });
+
+  const nonce = randomBytes(NONCE_BYTES);
+  const cipher = createCipheriv('aes-256-gcm', key, nonce);
+  const body = Buffer.concat([cipher.update(payload, 'utf8'), cipher.final()]);
+  const tag = cipher.getAuthTag();
+
+  return `${VERSION}.${Buffer.concat([nonce, tag, body]).toString('base64url')}`;
+}
+
+/**
+ * Open a sealed value, or throw.
+ *
+ * Throws rather than returning null for the same reason `readClientId` does: a
+ * caller cannot accidentally treat an unverified value as valid by forgetting a
+ * null check. Every failure — wrong key, tampered bytes, expired, malformed —
+ * raises the same error type, so nothing downstream can branch on which.
+ */
+export function openAuthState<T>(sealed: string, key: Buffer, nowMs: number = Date.now()): T {
+  assertKey(key);
+
+  if (typeof sealed !== 'string' || !sealed.startsWith(`${VERSION}.`)) {
+    throw new InvalidAuthStateError('not an authorization state issued by this server');
+  }
+
+  const raw = Buffer.from(sealed.slice(VERSION.length + 1), 'base64url');
+  if (raw.length <= NONCE_BYTES + TAG_BYTES) {
+    throw new InvalidAuthStateError('malformed authorization state');
+  }
+
+  const nonce = raw.subarray(0, NONCE_BYTES);
+  const tag = raw.subarray(NONCE_BYTES, NONCE_BYTES + TAG_BYTES);
+  const body = raw.subarray(NONCE_BYTES + TAG_BYTES);
+
+  let plaintext: string;
+  try {
+    const decipher = createDecipheriv('aes-256-gcm', key, nonce);
+    decipher.setAuthTag(tag);
+    plaintext = Buffer.concat([decipher.update(body), decipher.final()]).toString('utf8');
+  } catch {
+    // GCM's final() is what rejects a tampered or wrongly-keyed blob.
+    throw new InvalidAuthStateError('authorization state does not verify');
+  }
+
+  let parsed: { v: T; exp: number };
+  try {
+    parsed = JSON.parse(plaintext);
+  } catch {
+    throw new InvalidAuthStateError('authorization state payload is not JSON');
+  }
+
+  if (typeof parsed?.exp !== 'number' || !Number.isFinite(parsed.exp)) {
+    throw new InvalidAuthStateError('authorization state has no expiry');
+  }
+  if (nowMs >= parsed.exp) {
+    // Deliberately distinct wording in the message but the SAME error type, so
+    // the difference is visible in a log and invisible to a caller branching on
+    // the type. A sign-in that took too long is the common case here, not an
+    // attack.
+    throw new InvalidAuthStateError('authorization state has expired');
+  }
+
+  return parsed.v;
+}
+
+function assertKey(key: Buffer): void {
+  if (!Buffer.isBuffer(key) || key.length !== 32) {
+    // Not an InvalidAuthStateError: a wrong key is our misconfiguration, and it
+    // must not be reported to a caller as a bad state.
+    throw new Error('a 32-byte key is required to seal or open authorization state');
+  }
+}

--- a/src/http/config.ts
+++ b/src/http/config.ts
@@ -147,6 +147,39 @@ export function clientIdSigningKey(): string {
 }
 
 // ============================================================================
+// Authorization State Key
+// ============================================================================
+
+/**
+ * The key that seals authorization state. Derived, like the client id key, and
+ * from the same secret but a DIFFERENT label.
+ *
+ * The label is the whole point: one compromised or observed value must not help
+ * against the other. Same secret, same algorithm, different label gives two keys
+ * with no computable relationship — which is what lets a public, signed client
+ * id and an encrypted, secret-bearing auth state coexist under one environment
+ * variable.
+ *
+ * 32 bytes exactly, because AES-256-GCM takes a 32-byte key and a shorter or
+ * longer one is a throw rather than a silent weakening.
+ */
+const AUTH_STATE_KEY_LABEL = 'mcp-auth-state-v1';
+
+export function deriveAuthStateKey(clientSecret: string): Buffer {
+  if (!clientSecret) {
+    throw new Error(
+      'INSFORGE_CLIENT_SECRET is required: the authorization state key is derived from it'
+    );
+  }
+  return createHmac('sha256', clientSecret).update(AUTH_STATE_KEY_LABEL).digest();
+}
+
+/** Lazy for the same reason as clientIdSigningKey. */
+export function authStateKey(): Buffer {
+  return deriveAuthStateKey(INSFORGE_CONFIG.clientSecret);
+}
+
+// ============================================================================
 // Redis Configuration
 // ============================================================================
 //

--- a/src/http/oauth-manager.ts
+++ b/src/http/oauth-manager.ts
@@ -1,5 +1,7 @@
 import { createHash, randomBytes } from 'crypto';
 import { getRedisClient } from './redis.js';
+import { sealAuthState, openAuthState, InvalidAuthStateError } from './auth-state.js';
+import { authStateKey } from './config.js';
 import {
   validateToken,
   getProjectAccess,
@@ -76,12 +78,10 @@ interface TokenBinding {
 }
 
 // Redis key prefixes
-const AUTH_STATE_PREFIX = 'mcp:auth:state:';
 const TOKEN_BINDING_PREFIX = 'mcp:auth:binding:';
 const AUTH_CODE_PREFIX = 'mcp:auth:code:';
 
 // TTLs
-const AUTH_STATE_TTL = 10 * 60; // 10 minutes
 const AUTH_CODE_TTL = 5 * 60; // 5 minutes
 const TOKEN_BINDING_TTL = 30 * 24 * 60 * 60; // 30 days
 
@@ -121,9 +121,6 @@ export class OAuthManager {
       throw new Error(`Unsupported code_challenge_method: ${params.codeChallengeMethod}. Only S256 is supported.`);
     }
 
-    const redis = getRedisClient();
-    const stateId = generateCode();
-
     // Generate PKCE verifier for our request to Insforge
     const insforgeCodeVerifier = generateCodeVerifier();
     const insforgeCodeChallenge = generateCodeChallenge(insforgeCodeVerifier);
@@ -136,11 +133,10 @@ export class OAuthManager {
       createdAt: Date.now(),
     };
 
-    await redis.setex(
-      AUTH_STATE_PREFIX + stateId,
-      AUTH_STATE_TTL,
-      JSON.stringify(authState)
-    );
+    // The state IS the record. Nothing is written, so nothing has to be read
+    // back, expire, or be reachable from whichever instance handles the
+    // callback — the browser carries it there and only we can open it.
+    const stateId = sealAuthState(authState, authStateKey());
 
     return { stateId, insforgeCodeChallenge };
   }
@@ -149,14 +145,19 @@ export class OAuthManager {
    * Get authorization state
    */
   async getAuthorizationState(stateId: string): Promise<AuthorizationState | null> {
-    const redis = getRedisClient();
-    const data = await redis.get(AUTH_STATE_PREFIX + stateId);
-
-    if (!data) {
-      return null;
+    // Null, not a throw, because every caller already treats "no such state" as
+    // the ordinary case — a sign-in that took more than ten minutes. The reason
+    // it failed is logged rather than returned: a caller that could distinguish
+    // "expired" from "forged" would be an oracle for whoever is probing.
+    try {
+      return openAuthState<AuthorizationState>(stateId, authStateKey());
+    } catch (error) {
+      if (error instanceof InvalidAuthStateError) {
+        console.log(`[OAuth] Authorization state rejected: ${error.message}`);
+        return null;
+      }
+      throw error;
     }
-
-    return JSON.parse(data) as AuthorizationState;
   }
 
   /**
@@ -218,9 +219,15 @@ export class OAuthManager {
       })
     );
 
-    // Clean up the state
-    await redis.del(AUTH_STATE_PREFIX + stateId);
-
+    // Nothing to clean up: the state was never stored. It stops being accepted
+    // when its own expiry passes.
+    //
+    // That does mean a sealed state is replayable inside its ten minutes, where
+    // the deleted row was single-use. The bound on that is the platform: a
+    // replay re-presents an authorization code the platform has already
+    // consumed, and it refuses. So a replay reaches this method and then fails
+    // at the exchange — it cannot mint a second session. Worth stating rather
+    // than discovering, because "signed" and "single-use" are easy to conflate.
     return code;
   }
 


### PR DESCRIPTION
The Redis use that stops a login from *starting*, and the one Max measured on
the slug an hour ago:

```
GET /oauth/authorize  500  {"error":"server_error",
                            "error_description":"Failed to initiate authorization"}
oauth-manager.ts      createAuthorizationState -> getRedisClient()
```

A client could register (thanks to #82) and then never open a login.

## Sealed, not signed — the one real difference from client ids

| | client id (#82) | auth state (this) |
|---|---|---|
| contents | public registration | includes `insforgeCodeVerifier` |
| mechanism | HMAC signature | **AES-256-GCM encryption** |

The verifier is our PKCE secret for the platform call. A signed-but-readable
envelope would print it in the authorize URL, the browser's address bar and the
platform's logs — **precisely the party PKCE defends against.** The ceremony
would remain and the protection would not.

- fresh 96-bit nonce per seal (a repeated nonce is how GCM fails catastrophically)
- expiry lives **inside** the ciphertext, so it is covered by the auth tag and
  cannot be extended by whoever holds the blob — there is a test that flips bytes
  across the body and requires every one to be rejected
- one primitive for confidentiality and integrity, so there is no
  encrypt-then-MAC ordering to get wrong

## Key separation

Derived from `INSFORGE_CLIENT_SECRET` with a **different label** from the client
id key, so the two have no computable relationship. That is what lets a public
signed value and a secret-bearing encrypted one live under one environment
variable — still no new config. A test asserts the keys differ and that each
rejects the other's output.

## Replay, stated rather than discovered

A sealed state is replayable inside its ten minutes, where a deleted row was
single-use. The bound is the platform: a replay re-presents an authorization code
the platform has already consumed, and it refuses. So a replay reaches our method
and then fails at the exchange — **it cannot mint a second session.** "Signed" and
"single-use" are easy to conflate, so this is written next to the code.

## Size — the #82 trap one hop further along

The sealed state *contains* the client id, and then travels in the **platform's**
authorize URL, so a large registration inflates a request line we do not own.
Measured on a running server rather than estimated:

```
realistic registration   client_id  171   platform authorize URL  1037
largest #82 accepts      client_id 3980   platform authorize URL  6494   (limit 8192)
```

`MAX_CLIENT_ID_LENGTH` bounds this hop too, with room. That is luck rather than
design, and it is noted in the code: anyone raising that constant has to
re-measure *this* number, not only the one it was chosen for.

## Verified with no Redis process anywhere

```
POST /oauth/register    201   client_id 171 chars
GET  /oauth/authorize   302   -> the platform          (was 500)
```

171 tests.

## What this does NOT do

Sign-in still will not **complete**. Two Redis uses remain on the login path —
`/oauth/callback` (`setex` the token) and `/oauth/select-project` (`get` + `del`)
— and both are needed before Quinn's end-to-end pass can run. This removes the
one that stopped a login from starting; it does not make one finish, and I would
rather say so than let a green `/oauth/authorize` imply otherwise.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Move authorization state from a Redis row to a sealed AES-256-GCM value carried in the OAuth `state` parameter. This removes Redis from `/oauth/authorize`, keeps the PKCE verifier secret, and lets logins start reliably.

- **New Features**
  - Seal and verify auth state with AES-256-GCM: fresh nonce per seal, expiry inside the ciphertext, and tamper rejection.
  - Key separation: derive the auth-state key from `INSFORGE_CLIENT_SECRET` with a different label than the client-id signing key.
  - Replay is safe: a replay within 10 minutes cannot mint a second session because the platform refuses reused codes.
  - Size guard: measured authorize URL sizes; `MAX_CLIENT_ID_LENGTH` still bounds this hop, and must be re-measured if raised.

- **Bug Fixes**
  - `/oauth/authorize` works without Redis (302 to the platform instead of 500).
  - `getAuthorizationState` opens sealed values and logs rejections; returns null for invalid or expired state.

<sup>Written for commit b71caf97c768f11c03560b19aa0ebb2902981b09. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/insforge-mcp/pull/87?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

