### PR TITLE
The platform token rides in the state, not a row keyed by it

### DIFF
--- a/src/http/oauth-manager.ts
+++ b/src/http/oauth-manager.ts
@@ -57,6 +57,18 @@ interface AuthorizationState {
   // Our PKCE verifier for calling Insforge OAuth
   insforgeCodeVerifier: string;
 
+  /**
+   * The platform access token, present only AFTER the callback has exchanged
+   * the code for it.
+   *
+   * It used to live in its own Redis row (mcp:oauth:token:<state>) read twice
+   * by the project-selection page. Folding it into the state it was already
+   * keyed by removes the row and the second lookup — and it is safe here for
+   * exactly one reason: this envelope is encrypted, not signed. A bearer token
+   * in a signed-but-readable blob would be a bearer token in a URL.
+   */
+  platformAccessToken?: string;
+
   createdAt: number;
 }
 
@@ -103,6 +115,19 @@ function generateCode(): string {
  * OAuthManager handles the OAuth authorization flow and token-to-project binding
  */
 export class OAuthManager {
+  /**
+   * Re-seal an existing state with the platform token attached.
+   *
+   * Returns a NEW state_id: the sealed value IS the record, so adding a field
+   * necessarily produces a different string. The expiry restarts here, which
+   * matches what it replaces — the Redis token row carried its own fresh
+   * 10-minute TTL from the moment the callback wrote it, and the person still
+   * has a project to choose.
+   */
+  attachPlatformToken(authState: AuthorizationState, platformAccessToken: string): string {
+    return sealAuthState({ ...authState, platformAccessToken }, authStateKey());
+  }
+
   /**
    * Create a new authorization state (step 1 of OAuth flow)
    * Returns a state ID and the PKCE code challenge for Insforge OAuth

--- a/src/http/server.ts
+++ b/src/http/server.ts
@@ -516,14 +516,14 @@ app.get(OAUTH_ENDPOINTS.callback, async (req: Request, res: Response) => {
 
     console.log('[OAuth] Token received, redirecting to project selection...');
 
-    const redis = getRedisClient();
-    await redis.setex(
-      `mcp:oauth:token:${state}`,
-      10 * 60,
-      tokens.access_token
-    );
+    // The token rides inside the state instead of a row keyed by it. The
+    // state_id therefore CHANGES here — it is the record, so a record with one
+    // more field is a different string.
+    const stateWithToken = oauthManager.attachPlatformToken(authState, tokens.access_token);
 
-    res.redirect(`${SERVER_CONFIG.publicUrl}${OAUTH_ENDPOINTS.selectProject}?state_id=${state}`);
+    res.redirect(
+      `${SERVER_CONFIG.publicUrl}${OAUTH_ENDPOINTS.selectProject}?state_id=${encodeURIComponent(stateWithToken)}`
+    );
   } catch (error) {
     console.error('OAuth callback error:', error);
     getAnalyticsService().trackOAuthFailure({
@@ -550,16 +550,16 @@ app.get(OAUTH_ENDPOINTS.selectProject, async (req: Request, res: Response) => {
 
   try {
     const oauthManager = getOAuthManager();
-    const redis = getRedisClient();
-
-    const token = await redis.get(`mcp:oauth:token:${state_id}`);
-    if (!token) {
-      return res.status(400).send('Session expired. Please start the authorization process again.');
-    }
 
     const authState = await oauthManager.getAuthorizationState(state_id as string);
     if (!authState) {
-      return res.status(400).send('Invalid or expired state');
+      return res.status(400).send('Session expired. Please start the authorization process again.');
+    }
+    const token = authState.platformAccessToken;
+    if (!token) {
+      // A state that never went through the callback. Same message: from the
+      // person's side these are the same event — a sign-in that did not finish.
+      return res.status(400).send('Session expired. Please start the authorization process again.');
     }
 
     const projectGroups = await oauthManager.getAvailableProjects(token);
@@ -590,20 +590,15 @@ app.post(OAUTH_ENDPOINTS.selectProject, async (req: Request, res: Response) => {
 
   try {
     const oauthManager = getOAuthManager();
-    const redis = getRedisClient();
-
-    const token = await redis.get(`mcp:oauth:token:${state_id}`);
-    if (!token) {
-      return res.status(400).send('Session expired. Please start the authorization process again.');
-    }
 
     const authState = await oauthManager.getAuthorizationState(state_id as string);
-    if (!authState) {
+    if (!authState?.platformAccessToken) {
       return res.status(400).json({
         error: 'invalid_request',
         error_description: 'Invalid or expired state',
       });
     }
+    const token = authState.platformAccessToken;
 
     const code = await oauthManager.createAuthorizationCode(
       state_id as string,
@@ -611,7 +606,8 @@ app.post(OAUTH_ENDPOINTS.selectProject, async (req: Request, res: Response) => {
       project_id as string
     );
 
-    await redis.del(`mcp:oauth:token:${state_id}`);
+    // Nothing to delete: the token was never stored. It stops being usable
+    // when the sealed state it rides in expires.
 
     const redirectUrl = new URL(authState.redirectUri);
     redirectUrl.searchParams.set('code', code);


### PR DESCRIPTION
Third of the five Redis uses, and the one that made `/oauth/callback` and
`/oauth/select-project` need Redis at all:

```
callback        SETEX mcp:oauth:token:<state>   the platform access token
select-project  GET it twice (page render, then POST), then DEL
```

All three are keyed by the state the token already travels with. So fold it in:
`attachPlatformToken` re-seals the existing authorization state with the token
attached, and the callback redirects with that as the new `state_id`.

**The `state_id` changes at the callback, deliberately.** The sealed value *is*
the record, so a record with one more field is a different string — there is
nothing to update in place, which is the point.

## Why this is only safe because the envelope is encrypted

A platform access token is a bearer credential. A signed-but-readable blob would
put it in a URL, the address bar and the platform's logs. That is the property
`auth-state.ts` was built for, and it is the only reason the token can live here
rather than in a row.

Expiry restarts at the callback, matching what it replaces: the Redis token row
carried its own fresh 10-minute TTL from the moment it was written, and the
person still has a project to choose.

**`server.ts` now has no Redis call anywhere in the OAuth path** — the only
`getRedisClient()` left in that file is the boot ping.

## Measured with no Redis process anywhere

```
select-project, state WITHOUT a token   400  "Session expired..."
select-project, state WITH a token      401  from api.insforge.dev
                                             (fake token, so the platform
                                             refuses — but it GOT there)
select-project, garbage state           400
Redis errors in the server log          0

sealed state, no token            337 chars
sealed state, ~900-char token    1570 chars   (fits a URL with room)
```

The 401 is the result that matters: it means every state check passed and the
handler reached the platform, which is the whole path minus a real credential.

## Not a complete login yet

`createAuthorizationCode` still writes `mcp:auth:code:` and the token binding
writes `mcp:auth:binding:`, so the code exchange at `/oauth/token` is next.
**Two of five left.**

171 tests.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moves the platform access token from Redis into the encrypted OAuth state, removing Redis from `/oauth/callback` and `/oauth/select-project`. The callback reseals the state with the token and redirects with a new `state_id`.

- **Refactors**
  - Add `platformAccessToken?` to the authorization state and `attachPlatformToken` to reseal with the token.
  - Callback stores the token by resealing and redirects with the new, encoded `state_id`.
  - Project selection reads the token from state; removes Redis GET/DEL; consistent “Session expired” handling.
  - Expiry resets at callback to preserve the 10‑minute TTL behavior.
  - OAuth path in `server.ts` no longer calls Redis (only the boot ping remains).

<sup>Written for commit 632c8526c2118bcf69326c98ece0460eddaad174. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/insforge-mcp/pull/88?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

