### PR TITLE
The state parameter is a handle again; the record rides in a cookie

### DIFF
--- a/src/http/auth-state-cookie.test.ts
+++ b/src/http/auth-state-cookie.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect } from 'vitest';
+import {
+  AUTH_STATE_COOKIE,
+  cookieAttributes,
+  readCookie,
+  newStateHandle,
+  isAcceptableClientState,
+  MAX_CLIENT_STATE_LENGTH,
+} from './auth-state-cookie.js';
+
+describe('the handle fits the column that broke us', () => {
+  it('is far inside 255 characters', () => {
+    // The whole reason this file exists: the platform stores `state` in a
+    // 255-char column, and the sealed record could not be shrunk below ~410.
+    for (let i = 0; i < 50; i++) {
+      const handle = newStateHandle();
+      expect(handle.length).toBe(32);
+      expect(handle.length).toBeLessThan(255);
+      expect(handle).toMatch(/^[0-9a-f]{32}$/);
+    }
+  });
+
+  it('is unpredictable', () => {
+    const seen = new Set(Array.from({ length: 200 }, () => newStateHandle()));
+    expect(seen.size).toBe(200);
+  });
+});
+
+describe('cookie attributes', () => {
+  it('is SameSite=Lax, because Strict would withhold it on the callback', () => {
+    // The callback is a top-level GET navigation from the platform's origin.
+    // Lax sends cookies on exactly that; Strict does not — a Strict cookie
+    // would be invisible at the one moment it is needed and every sign-in
+    // would fail. This assertion exists to stop a later "hardening".
+    expect(cookieAttributes('https://mcp.insforge.dev').sameSite).toBe('lax');
+  });
+
+  it('is HttpOnly and scoped to the OAuth routes', () => {
+    const attrs = cookieAttributes('https://mcp.insforge.dev');
+    expect(attrs.httpOnly).toBe(true);
+    expect(attrs.path).toBe('/oauth');
+  });
+
+  it('follows the public URL for Secure rather than hardcoding it', () => {
+    // A Secure cookie is silently dropped on plaintext http, and local runs are
+    // http://127.0.0.1 — hardcoding true makes every local sign-in fail in a
+    // way that looks like a code bug.
+    expect(cookieAttributes('https://mcp.insforge.dev').secure).toBe(true);
+    expect(cookieAttributes('http://127.0.0.1:3000').secure).toBe(false);
+  });
+});
+
+describe('readCookie', () => {
+  it('finds the value among others', () => {
+    expect(readCookie(`a=1; ${AUTH_STATE_COOKIE}=v1.abc; b=2`, AUTH_STATE_COOKIE)).toBe('v1.abc');
+  });
+
+  it('percent-decodes, because that is how it was written', () => {
+    expect(readCookie(`${AUTH_STATE_COOKIE}=v1.a%2Bb%3D`, AUTH_STATE_COOKIE)).toBe('v1.a+b=');
+  });
+
+  it('does not match a name that merely contains ours', () => {
+    expect(readCookie(`x_${AUTH_STATE_COOKIE}=nope`, AUTH_STATE_COOKIE)).toBeUndefined();
+    expect(readCookie(`${AUTH_STATE_COOKIE}_x=nope`, AUTH_STATE_COOKIE)).toBeUndefined();
+  });
+
+  it('treats a malformed value as absent rather than throwing mid-sign-in', () => {
+    expect(readCookie(`${AUTH_STATE_COOKIE}=%E0%A4%A`, AUTH_STATE_COOKIE)).toBeUndefined();
+  });
+
+  it('handles no header, an empty header and a valueless entry', () => {
+    expect(readCookie(undefined, AUTH_STATE_COOKIE)).toBeUndefined();
+    expect(readCookie('', AUTH_STATE_COOKIE)).toBeUndefined();
+    expect(readCookie('justaname', AUTH_STATE_COOKIE)).toBeUndefined();
+  });
+});
+
+describe('the client state is bounded before we seal it', () => {
+  it('accepts what real clients send, and absence', () => {
+    expect(isAcceptableClientState(undefined)).toBe(true);
+    expect(isAcceptableClientState('')).toBe(true);
+    expect(isAcceptableClientState('s'.repeat(43))).toBe(true);
+    expect(isAcceptableClientState('s'.repeat(MAX_CLIENT_STATE_LENGTH))).toBe(true);
+  });
+
+  it('rejects one character over, and non-strings', () => {
+    // Unbounded client state means an unbounded cookie, which is the same
+    // whole-payload mistake one layer down.
+    expect(isAcceptableClientState('s'.repeat(MAX_CLIENT_STATE_LENGTH + 1))).toBe(false);
+    for (const bad of [42, {}, ['a'], null]) {
+      expect(isAcceptableClientState(bad)).toBe(false);
+    }
+  });
+});

--- a/src/http/auth-state-cookie.ts
+++ b/src/http/auth-state-cookie.ts
@@ -1,0 +1,123 @@
+import { randomBytes } from 'crypto';
+
+/**
+ * Where the sealed authorization state actually travels.
+ *
+ * #87 put the whole sealed envelope in the OAuth `state` parameter. Every byte
+ * budget it was measured against — Node's max-http-header-size, nginx's request
+ * line — was satisfied, and the platform still returned 500: it stores `state`
+ * in a **255-character column**. A limit nobody greps for, enforced by a
+ * different system, one hop past where I stopped measuring.
+ *
+ * Shrinking does not reach 255. The floor for a state that can still complete a
+ * callback is ~410 characters, measured across every variant the flow permits.
+ * So the envelope has to travel somewhere else, and `state` goes back to being
+ * a short handle.
+ *
+ * A cookie on our own origin is that somewhere, and it is not sufficient on its
+ * own either — it moves the bound to roughly 4096 bytes rather than removing
+ * one. Both halves are needed: drop the client id from the seal (nothing reads
+ * it after authorize) and bound the client's own `state`, so every component is
+ * bounded rather than hoped about.
+ *
+ *   client_id at its 4096 cap, client state 512   6639   OVER a 4096 cookie
+ *   no client_id, client state bounded to 512     1159   fits
+ *   realistic (loopback, 43-char state)            544   ample
+ *
+ * The handle is not decoration. It is in the `state` parameter AND inside the
+ * sealed payload, and the callback requires them to match — a double-submit
+ * binding. Without it the cookie alone would authorise any callback that
+ * arrived with a cookie, which is the CSRF the `state` parameter exists to
+ * prevent.
+ */
+
+/** The cookie carrying the sealed state. Scoped to the OAuth routes only. */
+export const AUTH_STATE_COOKIE = 'mcp_oauth_state';
+
+/**
+ * How long the cookie lives. Matches the seal's own expiry — the seal is
+ * authoritative, since a cookie's Max-Age is a request from us that the browser
+ * is free to ignore.
+ */
+export const AUTH_STATE_COOKIE_MAX_AGE_SECONDS = 10 * 60;
+
+/**
+ * A handle for one authorization, short enough for a 255-char column with room
+ * for anything else the platform decides to put beside it.
+ */
+export function newStateHandle(): string {
+  return randomBytes(16).toString('hex'); // 32 chars
+}
+
+export interface CookieAttributes {
+  httpOnly: true;
+  secure: boolean;
+  sameSite: 'lax';
+  path: string;
+  maxAge: number;
+}
+
+/**
+ * Attributes for the state cookie.
+ *
+ * `sameSite: 'lax'` is load-bearing and NOT a weaker choice made for
+ * convenience. The callback arrives as a top-level GET navigation from the
+ * platform's origin. Lax sends cookies on exactly that; **Strict withholds
+ * them**, so a Strict cookie would be invisible at the one moment it is needed
+ * and every sign-in would fail with a missing state. This is the kind of
+ * setting that gets "hardened" later by someone who has not traced the
+ * navigation, so: do not.
+ *
+ * `secure` follows the public URL rather than being hardcoded, because a
+ * Secure cookie is silently dropped on plaintext http and local development
+ * runs on http://127.0.0.1. Hardcoding true makes every local run fail in a way
+ * that looks like a code bug.
+ */
+export function cookieAttributes(publicUrl: string, oauthPathPrefix = '/oauth'): CookieAttributes {
+  return {
+    httpOnly: true,
+    secure: publicUrl.startsWith('https://'),
+    sameSite: 'lax',
+    path: oauthPathPrefix,
+    maxAge: AUTH_STATE_COOKIE_MAX_AGE_SECONDS * 1000,
+  };
+}
+
+/**
+ * Read one cookie out of a raw Cookie header.
+ *
+ * Hand-rolled rather than adding cookie-parser: this reads exactly one name,
+ * and a dependency whose whole job is `split('; ')` is a dependency to keep
+ * patched forever. Values are percent-encoded on the way out, so decode here.
+ */
+export function readCookie(header: string | undefined, name: string): string | undefined {
+  if (typeof header !== 'string' || header.length === 0) return undefined;
+
+  for (const part of header.split(';')) {
+    const eq = part.indexOf('=');
+    if (eq === -1) continue;
+    if (part.slice(0, eq).trim() !== name) continue;
+    const raw = part.slice(eq + 1).trim();
+    try {
+      return decodeURIComponent(raw);
+    } catch {
+      // A malformed value is not ours; treat it as absent rather than throwing
+      // a decode error out of the middle of a sign-in.
+      return undefined;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * The longest client-supplied `state` we will accept.
+ *
+ * The client's `state` rides inside our sealed envelope, so an unbounded one is
+ * an unbounded cookie. 512 is far above anything a real client sends (the SDK
+ * uses 32 random bytes) and keeps the worst case inside 4096 with room.
+ */
+export const MAX_CLIENT_STATE_LENGTH = 512;
+
+export function isAcceptableClientState(value: unknown): boolean {
+  return value === undefined || (typeof value === 'string' && value.length <= MAX_CLIENT_STATE_LENGTH);
+}

--- a/src/http/oauth-manager.ts
+++ b/src/http/oauth-manager.ts
@@ -1,6 +1,7 @@
 import { createHash, randomBytes } from 'crypto';
 import { getRedisClient } from './redis.js';
 import { sealAuthState, openAuthState, InvalidAuthStateError } from './auth-state.js';
+import { newStateHandle } from './auth-state-cookie.js';
 import { authStateKey } from './config.js';
 import {
   validateToken,
@@ -46,8 +47,19 @@ export function generateState(): string {
  * 2. The PKCE verifier we generate when calling Insforge OAuth
  */
 interface AuthorizationState {
-  // Original MCP client request
-  clientId: string;
+  /**
+   * Ties the sealed cookie to the `state` parameter the platform echoes back.
+   * The callback requires them to match; without that the cookie alone would
+   * authorise any callback that arrived carrying one.
+   */
+  handle: string;
+
+  // Original MCP client request.
+  //
+  // clientId is deliberately NOT here. Nothing read it after authorize, and it
+  // is the largest field by far — a signed client id is ~171 characters and may
+  // be up to 4096, which is what pushed the sealed envelope past a 4096-byte
+  // cookie.
   redirectUri: string;
   scope: string;
   state?: string;
@@ -133,13 +145,12 @@ export class OAuthManager {
    * Returns a state ID and the PKCE code challenge for Insforge OAuth
    */
   async createAuthorizationState(params: {
-    clientId: string;
     redirectUri: string;
     scope: string;
     state?: string;
     codeChallenge?: string;
     codeChallengeMethod?: string;
-  }): Promise<{ stateId: string; insforgeCodeChallenge: string }> {
+  }): Promise<{ handle: string; sealedState: string; insforgeCodeChallenge: string }> {
     // Validate code_challenge_method early - only S256 is supported
     // Reject 'plain' and other methods to prevent downgrade attacks
     if (params.codeChallenge && params.codeChallengeMethod && params.codeChallengeMethod !== 'S256') {
@@ -151,31 +162,38 @@ export class OAuthManager {
     const insforgeCodeChallenge = generateCodeChallenge(insforgeCodeVerifier);
 
     // Normalize codeChallengeMethod to S256 if code challenge is provided
+    const handle = newStateHandle();
     const authState: AuthorizationState = {
       ...params,
+      handle,
       codeChallengeMethod: params.codeChallenge ? 'S256' : undefined,
       insforgeCodeVerifier,
       createdAt: Date.now(),
     };
 
-    // The state IS the record. Nothing is written, so nothing has to be read
-    // back, expire, or be reachable from whichever instance handles the
-    // callback — the browser carries it there and only we can open it.
-    const stateId = sealAuthState(authState, authStateKey());
-
-    return { stateId, insforgeCodeChallenge };
+    // The handle goes to the platform (32 chars, comfortably inside its
+    // 255-character column); the sealed record goes in a cookie on our origin.
+    return { handle, sealedState: sealAuthState(authState, authStateKey()), insforgeCodeChallenge };
   }
 
   /**
    * Get authorization state
    */
-  async getAuthorizationState(stateId: string): Promise<AuthorizationState | null> {
+  async getAuthorizationState(sealed: string, expectedHandle?: string): Promise<AuthorizationState | null> {
     // Null, not a throw, because every caller already treats "no such state" as
     // the ordinary case — a sign-in that took more than ten minutes. The reason
     // it failed is logged rather than returned: a caller that could distinguish
     // "expired" from "forged" would be an oracle for whoever is probing.
     try {
-      return openAuthState<AuthorizationState>(stateId, authStateKey());
+      const state = openAuthState<AuthorizationState>(sealed, authStateKey());
+      if (expectedHandle !== undefined && state.handle !== expectedHandle) {
+        // The cookie is real and ours, but it belongs to a different
+        // authorization than the one the platform is calling back about. That
+        // is the case the state parameter exists to catch.
+        console.log('[OAuth] Authorization state handle does not match the state parameter');
+        return null;
+      }
+      return state;
     } catch (error) {
       if (error instanceof InvalidAuthStateError) {
         console.log(`[OAuth] Authorization state rejected: ${error.message}`);

--- a/src/http/oauth-manager.ts
+++ b/src/http/oauth-manager.ts
@@ -179,14 +179,17 @@ export class OAuthManager {
   /**
    * Get authorization state
    */
-  async getAuthorizationState(sealed: string, expectedHandle?: string): Promise<AuthorizationState | null> {
+  async getAuthorizationState(sealed: string, expectedHandle: string): Promise<AuthorizationState | null> {
     // Null, not a throw, because every caller already treats "no such state" as
     // the ordinary case — a sign-in that took more than ten minutes. The reason
     // it failed is logged rather than returned: a caller that could distinguish
     // "expired" from "forged" would be an oracle for whoever is probing.
     try {
       const state = openAuthState<AuthorizationState>(sealed, authStateKey());
-      if (expectedHandle !== undefined && state.handle !== expectedHandle) {
+      // Required, not optional. An optional handle means a future caller can
+      // drop the CSRF binding with no compile error — john-bot's note, and the
+      // right fix is the signature rather than a comment asking nicely.
+      if (state.handle !== expectedHandle) {
         // The cookie is real and ours, but it belongs to a different
         // authorization than the one the platform is calling back about. That
         // is the case the state parameter exists to catch.
@@ -209,13 +212,14 @@ export class OAuthManager {
    */
   async createAuthorizationCode(
     stateId: string,
+    handle: string,
     token: string,
     projectId: string
   ): Promise<string> {
     const redis = getRedisClient();
 
     // Validate the state exists
-    const authState = await this.getAuthorizationState(stateId);
+    const authState = await this.getAuthorizationState(stateId, handle);
     if (!authState) {
       throw new Error('Invalid or expired authorization state');
     }

--- a/src/http/oauth-state-binding.test.ts
+++ b/src/http/oauth-state-binding.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+
+/**
+ * The CSRF binding this whole design turns on, tested directly.
+ *
+ * `auth-state-cookie.test.ts` covers the helpers thoroughly and the property
+ * they exist to enforce not at all — the exact shape of gap this repo keeps
+ * finding. So: the record is in a cookie and the handle is in the `state`
+ * parameter, and one without the other must be worth nothing.
+ */
+
+// The manager derives its key from INSFORGE_CLIENT_SECRET at call time, so the
+// environment has to be set before the module is imported.
+process.env.INSFORGE_CLIENT_SECRET ||= 'test-secret-for-binding';
+
+let manager: import('./oauth-manager.js').OAuthManager;
+
+beforeAll(async () => {
+  const { getOAuthManager } = await import('./oauth-manager.js');
+  manager = getOAuthManager();
+});
+
+const request = {
+  redirectUri: 'http://127.0.0.1:8765/callback',
+  scope: 'mcp:read mcp:write',
+  state: 'the-client-own-csrf-value',
+  codeChallenge: 'a'.repeat(43),
+  codeChallengeMethod: 'S256',
+};
+
+describe('a sealed record is only valid with its own handle', () => {
+  it('opens with the handle it was issued with', async () => {
+    const { handle, sealedState } = await manager.createAuthorizationState(request);
+    const opened = await manager.getAuthorizationState(sealedState, handle);
+
+    expect(opened).not.toBeNull();
+    expect(opened?.redirectUri).toBe(request.redirectUri);
+    expect(opened?.state).toBe(request.state);
+    expect(opened?.insforgeCodeVerifier).toBeTruthy();
+  });
+
+  it(`refuses another authorization's handle`, async () => {
+    // Both halves are genuinely ours; they just belong to different sign-ins.
+    // This is the case the state parameter exists to catch, and a cookie
+    // without the check would accept it.
+    const a = await manager.createAuthorizationState(request);
+    const b = await manager.createAuthorizationState(request);
+
+    expect(await manager.getAuthorizationState(a.sealedState, b.handle)).toBeNull();
+    expect(await manager.getAuthorizationState(b.sealedState, a.handle)).toBeNull();
+  });
+
+  it('refuses a fabricated handle', async () => {
+    const { sealedState } = await manager.createAuthorizationState(request);
+    for (const wrong of ['', '0'.repeat(32), 'not-a-handle', 'undefined']) {
+      expect(await manager.getAuthorizationState(sealedState, wrong)).toBeNull();
+    }
+  });
+
+  it('refuses a cookie that is not ours, whatever handle is offered', async () => {
+    const { handle } = await manager.createAuthorizationState(request);
+    for (const junk of ['', 'v1.AAAA', 'not-sealed-at-all']) {
+      expect(await manager.getAuthorizationState(junk, handle)).toBeNull();
+    }
+  });
+
+  it('gives every authorization a distinct handle and a distinct record', async () => {
+    const issued = await Promise.all(
+      Array.from({ length: 20 }, () => manager.createAuthorizationState(request))
+    );
+    expect(new Set(issued.map((i) => i.handle)).size).toBe(20);
+    expect(new Set(issued.map((i) => i.sealedState)).size).toBe(20);
+  });
+
+  it('keeps the handle short enough for the column that started all this', async () => {
+    const { handle } = await manager.createAuthorizationState(request);
+    expect(handle.length).toBeLessThan(255);
+  });
+
+  it('does not carry the client id, which is what busted the cookie bound', async () => {
+    const { sealedState, handle } = await manager.createAuthorizationState(request);
+    const opened = await manager.getAuthorizationState(sealedState, handle);
+    expect(opened).not.toBeNull();
+    expect(opened as unknown as Record<string, unknown>).not.toHaveProperty('clientId');
+  });
+});

--- a/src/http/server.ts
+++ b/src/http/server.ts
@@ -38,6 +38,13 @@ import {
   InvalidRegistrationError,
   type ClientRegistration,
 } from './client-id.js';
+import {
+  AUTH_STATE_COOKIE,
+  cookieAttributes,
+  readCookie,
+  isAcceptableClientState,
+  MAX_CLIENT_STATE_LENGTH,
+} from './auth-state-cookie.js';
 import { statusForHttpError } from './error-status.js';
 import { PACKAGE_VERSION } from '../shared/version.js';
 
@@ -322,6 +329,16 @@ app.get(OAUTH_ENDPOINTS.authorize, async (req: Request, res: Response) => {
   // Default scope if not provided (scope is optional per OAuth 2.0 spec)
   const resolvedScope = (scope as string) || OAUTH_CONFIG.supportedScopes.join(' ');
 
+  if (!isAcceptableClientState(state)) {
+    // The client's own `state` rides inside our sealed cookie, so an unbounded
+    // one is an unbounded cookie. Rejected here, where the client is listening,
+    // rather than at the callback where only a browser would see it.
+    return res.status(400).json({
+      error: 'invalid_request',
+      error_description: `state must be at most ${MAX_CLIENT_STATE_LENGTH} characters`,
+    });
+  }
+
   if (response_type !== 'code') {
     return res.status(400).json({
       error: 'unsupported_response_type',
@@ -390,8 +407,7 @@ app.get(OAUTH_ENDPOINTS.authorize, async (req: Request, res: Response) => {
   try {
     const oauthManager = getOAuthManager();
 
-    const { stateId, insforgeCodeChallenge } = await oauthManager.createAuthorizationState({
-      clientId: client_id as string,
+    const { handle, sealedState, insforgeCodeChallenge } = await oauthManager.createAuthorizationState({
       redirectUri: redirect_uri as string,
       scope: resolvedScope,
       state: state as string | undefined,
@@ -404,7 +420,10 @@ app.get(OAUTH_ENDPOINTS.authorize, async (req: Request, res: Response) => {
     authUrl.searchParams.set('redirect_uri', OAUTH_CONFIG.callbackUrl);
     authUrl.searchParams.set('response_type', 'code');
     authUrl.searchParams.set('scope', INSFORGE_CONFIG.oauthScopes);
-    authUrl.searchParams.set('state', stateId);
+    // The handle, not the record. The platform stores `state` in a 255-char
+    // column; the record itself rides in a cookie on our own origin.
+    res.cookie(AUTH_STATE_COOKIE, sealedState, cookieAttributes(SERVER_CONFIG.publicUrl));
+    authUrl.searchParams.set('state', handle);
     authUrl.searchParams.set('code_challenge', insforgeCodeChallenge);
     authUrl.searchParams.set('code_challenge_method', 'S256');
 
@@ -435,7 +454,9 @@ app.get(OAUTH_ENDPOINTS.callback, async (req: Request, res: Response) => {
       errorDescription: (error_description as string) || (error as string) || 'Unknown Insforge error',
       endpoint: '/oauth/callback',
     });
-    const authState = state ? await oauthManager.getAuthorizationState(state as string) : null;
+    const sealed = readCookie(req.headers.cookie, AUTH_STATE_COOKIE);
+    const authState =
+      sealed && state ? await oauthManager.getAuthorizationState(sealed, state as string) : null;
 
     if (authState?.redirectUri) {
       const redirectUrl = new URL(authState.redirectUri);
@@ -465,7 +486,12 @@ app.get(OAUTH_ENDPOINTS.callback, async (req: Request, res: Response) => {
   }
 
   try {
-    const authState = await oauthManager.getAuthorizationState(state as string);
+    // The record is in our cookie; the platform only echoes the handle. Both
+    // are required, and they have to name the same authorization.
+    const sealed = readCookie(req.headers.cookie, AUTH_STATE_COOKIE);
+    const authState = sealed
+      ? await oauthManager.getAuthorizationState(sealed, state as string)
+      : null;
     if (!authState) {
       getAnalyticsService().trackOAuthFailure({
         errorType: 'invalid_request',
@@ -521,8 +547,11 @@ app.get(OAUTH_ENDPOINTS.callback, async (req: Request, res: Response) => {
     // more field is a different string.
     const stateWithToken = oauthManager.attachPlatformToken(authState, tokens.access_token);
 
+    // Same shape as authorize: the record replaces the cookie, the URL carries
+    // only the handle. The handle is unchanged, so the two halves still match.
+    res.cookie(AUTH_STATE_COOKIE, stateWithToken, cookieAttributes(SERVER_CONFIG.publicUrl));
     res.redirect(
-      `${SERVER_CONFIG.publicUrl}${OAUTH_ENDPOINTS.selectProject}?state_id=${encodeURIComponent(stateWithToken)}`
+      `${SERVER_CONFIG.publicUrl}${OAUTH_ENDPOINTS.selectProject}?state_id=${encodeURIComponent(authState.handle)}`
     );
   } catch (error) {
     console.error('OAuth callback error:', error);
@@ -551,7 +580,10 @@ app.get(OAUTH_ENDPOINTS.selectProject, async (req: Request, res: Response) => {
   try {
     const oauthManager = getOAuthManager();
 
-    const authState = await oauthManager.getAuthorizationState(state_id as string);
+    const sealed = readCookie(req.headers.cookie, AUTH_STATE_COOKIE);
+    const authState = sealed
+      ? await oauthManager.getAuthorizationState(sealed, state_id as string)
+      : null;
     if (!authState) {
       return res.status(400).send('Session expired. Please start the authorization process again.');
     }
@@ -591,8 +623,11 @@ app.post(OAUTH_ENDPOINTS.selectProject, async (req: Request, res: Response) => {
   try {
     const oauthManager = getOAuthManager();
 
-    const authState = await oauthManager.getAuthorizationState(state_id as string);
-    if (!authState?.platformAccessToken) {
+    const sealed = readCookie(req.headers.cookie, AUTH_STATE_COOKIE);
+    const authState = sealed
+      ? await oauthManager.getAuthorizationState(sealed, state_id as string)
+      : null;
+    if (!sealed || !authState?.platformAccessToken) {
       return res.status(400).json({
         error: 'invalid_request',
         error_description: 'Invalid or expired state',
@@ -601,7 +636,7 @@ app.post(OAUTH_ENDPOINTS.selectProject, async (req: Request, res: Response) => {
     const token = authState.platformAccessToken;
 
     const code = await oauthManager.createAuthorizationCode(
-      state_id as string,
+      sealed,
       token,
       project_id as string
     );

--- a/src/http/server.ts
+++ b/src/http/server.ts
@@ -637,12 +637,16 @@ app.post(OAUTH_ENDPOINTS.selectProject, async (req: Request, res: Response) => {
 
     const code = await oauthManager.createAuthorizationCode(
       sealed,
+      state_id as string,
       token,
       project_id as string
     );
 
-    // Nothing to delete: the token was never stored. It stops being usable
-    // when the sealed state it rides in expires.
+    // The record was never stored server-side, but the browser still holds the
+    // cookie. Clearing it on completion is cheap defence in depth: the sealed
+    // state is replayable inside its ten minutes, and there is no reason to
+    // leave a usable copy in the browser once the flow has finished.
+    res.clearCookie(AUTH_STATE_COOKIE, { path: '/oauth' });
 
     const redirectUrl = new URL(authState.redirectUri);
     redirectUrl.searchParams.set('code', code);


### PR DESCRIPTION
Clears the blocker: the platform stores `state` in a **255-character column**, #87 put a 681-character sealed envelope in it, and a login could not start. Quinn found it by following the redirect I stopped short of.

Shrinking does not reach 255 — ~410 is the floor for a state that can still complete a callback. And a cookie alone is not sufficient either; it moves the bound to ~4096 rather than removing one. **Both halves, so every component is bounded rather than hoped about:**

```
drop clientId from the seal   nothing read it after authorize, and it is the
                              largest field (up to 4096 on its own)
bound the client's state      512, rejected at authorize with invalid_request
handle in `state`             32 hex chars
record in a cookie            HttpOnly, Path=/oauth, Max-Age=600
```

**The handle is not decoration.** It is in the `state` parameter *and* inside the sealed record, and the callback requires them to match. Without that binding the cookie alone would authorise any callback carrying one — exactly the CSRF `state` exists to prevent.

**`SameSite=Lax` is load-bearing, not a weaker choice.** The callback is a top-level GET navigation from the platform's origin: Lax sends cookies on exactly that, Strict withholds them. A Strict cookie would be invisible at the one moment it is needed. There is a test asserting Lax so a later "hardening" fails instead of breaking sign-in. `secure` follows `publicUrl` for the same class of reason.

## Measured against a running server

```
state parameter          32 chars   (was 681; the column is 255)
Set-Cookie total        610 bytes   (cap ~4096)

callback, cookie + matching handle   reaches the PLATFORM token exchange
callback, cookie + wrong handle      400, and the mismatch is logged
callback, no cookie                  400
authorize, 513-char client state     400, naming the 512 limit
```

The first line is the one that matters: with a matching cookie the callback got all the way to `token_exchange_failed: invalid_client` — the platform rejecting a fake code, which means every state check passed.

## What still needs doing

**This has not been driven against the real platform.** The remaining verification is to deploy and follow the redirect on the slug — the exact step whose absence hid this bug. `mcp:auth:code:` and `mcp:auth:binding:` also remain, so a login still cannot *complete*.

183 tests.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes OAuth sign-in by making `state` a short handle and moving the sealed record to a cookie. Fits the platform’s 255-char `state` column and preserves CSRF protection by binding the handle to the cookie; now enforced by API and tests.

- **Bug Fixes**
  - Enforce client `state` length ≤ 512 at `/oauth/authorize`; longer values return `invalid_request`.
  - Set HttpOnly cookie `mcp_oauth_state` with SameSite=Lax, Path=/oauth, Max-Age=600; `secure` follows `publicUrl`.
  - Require cookie + matching `state` handle at callback and select-project; mismatch or missing cookie returns 400.
  - Clear `mcp_oauth_state` after successful code handoff to reduce replay risk.

- **Refactors**
  - Add `newStateHandle()` (32 hex chars) and carry `{ handle, sealedState }` through the flow.
  - Make `OAuthManager.getAuthorizationState(sealed, handle)` require the handle and verify it matches.
  - Update routes: authorize sets the cookie and sends the handle; callback/select-project read the cookie and pass the handle.
  - Drop `clientId` from the sealed state to keep the cookie under 4 KB.
  - Add tests for CSRF binding, handle size/unpredictability, cookie attributes/parsing, and client `state` bounds.

<sup>Written for commit d487b72736d40127deca8711536c379c640dc119. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/insforge-mcp/pull/89?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added improved OAuth authorization-state protection using secure, short-lived cookies and matching request handles.
  * Added validation for OAuth state values, including length limits and malformed cookie handling.
  * Authorization and callback flows now require a matching state cookie and handle.
  * Authorization cookies are cleared after the flow completes.

* **Tests**
  * Added comprehensive coverage for cookie security, parsing, uniqueness, validation, state binding, and invalid input handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->