### PR TITLE
The page promised a repair that does not repair

### DIFF
--- a/src/http/oauth-error-response.test.ts
+++ b/src/http/oauth-error-response.test.ts
@@ -65,6 +65,7 @@ describe('every browser-visible failure says what to do', () => {
     for (const error of ['invalid_client', 'invalid_request']) {
       const action = humanFormOf({ error }, MCP_URL).action as string[];
       expect(action).toEqual([
+        'codex mcp logout insforge',
         `npx add-mcp remove ${MCP_URL} -y`,
         'npx add-mcp https://mcp.insforge.dev/mcp',
       ]);
@@ -72,16 +73,32 @@ describe('every browser-visible failure says what to do', () => {
     }
   });
 
-  it('removes before adding, so it is not a no-op on an unchanged URL', () => {
+  it('clears the saved authorisation before reconnecting', () => {
     // add-mcp deep-merges under the server key and byte-preserves the rest, and
     // the key is inferred from the hostname. So on a same-hostname cutover a
     // bare `add-mcp <url>` rewrites an identical entry and changes nothing:
     // the stuck user runs it, fails identically, and opens a ticket. Removing
     // first is what makes the instruction do something — and it is correct on
     // a new hostname too, where it clears the stale entry anyway.
-    const [first, second] = reconnectCommand(MCP_URL);
-    expect(first).toContain('remove');
-    expect(second).toContain(MCP_URL);
+    // Blair ran these as a stuck user: on an unchanged hostname remove+add
+    // rebuilds the SAME mcpOAuth key and picks the dead registration back up,
+    // so the commands alone repair nothing. Clearing the client's saved
+    // authorisation is the step that works, and it comes first.
+    const [logout, remove, add] = reconnectCommand(MCP_URL);
+    expect(logout).toContain('logout');
+    expect(remove).toContain('remove');
+    expect(add).toContain(MCP_URL);
+  });
+
+  it('does not promise the reconnect alone will work', () => {
+    // The page used to say "add it back ... and this will complete normally".
+    // On an unchanged hostname that promise is false for Claude Code, and it
+    // was aimed at exactly the people it would fail.
+    for (const error of ['invalid_client', 'invalid_request']) {
+      const { message } = humanFormOf({ error }, MCP_URL);
+      expect(message).not.toContain('complete normally');
+      expect(message).toMatch(/Clear authentication/);
+    }
   });
 
   it('names the host the person is actually talking to, in BOTH commands', () => {
@@ -95,12 +112,15 @@ describe('every browser-visible failure says what to do', () => {
     // so passing the URL is exact on every host.
     const slug = 'https://keen-pulse-fsjr9.run.mcp-use.com/mcp';
     expect(reconnectCommand(slug)).toEqual([
+      'codex mcp logout insforge',
       `npx add-mcp remove ${slug} -y`,
       `npx add-mcp ${slug}`,
     ]);
-    for (const command of reconnectCommand(slug)) {
+    // The two add-mcp commands are host-derived; the codex one names the
+    // server as that client stored it, which is our product name on any host.
+    for (const command of reconnectCommand(slug).slice(1)) {
       expect(command).toContain('keen-pulse-fsjr9');
-      expect(command).not.toContain('insforge');
+      expect(command).not.toContain('insforge.dev');
     }
   });
 

--- a/src/http/oauth-error-response.ts
+++ b/src/http/oauth-error-response.ts
@@ -76,11 +76,30 @@ export interface HumanForm {
  * name, and that the package stores no tokens of its own (its single "oauth"
  * reference is an oauthScopes CONFIG field).
  *
- * What this still cannot promise: whether removing the config entry also drops
- * the client's saved OAuth registration is client-specific — add-mcp deletes
- * its config key and nothing more. If some client keys its registration by
- * server name rather than URL, even remove+add leaves it stuck. That is a real
- * test on a real editor, not something to settle in a comment.
+ * AND THE ANSWER, which is no. Blair ran these commands as a stuck user
+ * instead of reasoning about them: for Claude Code the saved authorisation
+ * lives in `mcpOAuth` under `name|sha256(type,url,headers)`, a store add-mcp
+ * never touches. Removing and re-adding the SAME url rebuilds the identical key
+ * and picks the dead registration straight back up. So on an unchanged
+ * hostname these commands do not repair anything on their own, and the page
+ * used to promise "this will complete normally" — a promise that would have
+ * been broken for exactly the population it was written for.
+ *
+ * The step that actually works is clearing the client's saved authorisation,
+ * and it is client-specific:
+ *
+ *   Claude Code   /mcp -> pick the server -> Clear authentication   (a UI action)
+ *   Codex         codex mcp logout insforge
+ *
+ * The Claude Code one is not a command, so it belongs in the sentence rather
+ * than in a code block a person would try to paste. On a NEW hostname the
+ * remove/add pair does repair by itself — different url, different key, no
+ * saved state — so both are printed and the wording no longer claims more than
+ * either can deliver.
+ *
+ * Still unverified, and stated rather than implied: nobody has watched a real
+ * Claude Code reuse that record against a live server. Blair proved the record
+ * survives the commands; the reuse is inferred from the key derivation.
  *
  * Built from publicUrl, which is the CANONICAL host this deployment is
  * configured to be — deliberately not the host the request arrived on. The Host
@@ -120,7 +139,11 @@ export function reconnectCommand(mcpUrl: string): string[] {
   // chunk-2LJORNPV.js). So passing the URL is exact, host-derived by
   // construction, and cannot drift the way a copy of their inference rule
   // would.
-  return [`npx add-mcp remove ${mcpUrl} -y`, `npx add-mcp ${mcpUrl}`];
+  return [
+    'codex mcp logout insforge',
+    `npx add-mcp remove ${mcpUrl} -y`,
+    `npx add-mcp ${mcpUrl}`,
+  ];
 }
 
 /**
@@ -134,12 +157,13 @@ export function humanFormOf(body: OAuthErrorBody, mcpUrl: string): HumanForm {
   switch (body.error) {
     case 'invalid_client':
       return {
-        heading: 'This connection needs to be set up again',
+        heading: 'Your client is holding a sign-in that no longer works',
         message:
-          'The app you are connecting from is not registered with this server any more. ' +
-          'Nothing is wrong with your account and no data was lost — remove the InsForge MCP ' +
-          'server from your client and add it back with the command below, and this will ' +
-          'complete normally.',
+          'Nothing is wrong with your account and no data was lost. Your editor has saved an ' +
+          'authorisation for this server that this server no longer recognises, and it will keep ' +
+          'reusing it until you clear it. In Claude Code: run /mcp, pick this server, and choose ' +
+          'Clear authentication. In Codex: run the first command below. Then reconnect with the ' +
+          'last one.',
         action: reconnectCommand(mcpUrl),
       };
 
@@ -149,11 +173,12 @@ export function humanFormOf(body: OAuthErrorBody, mcpUrl: string): HumanForm {
       // cause is not something the person can inspect, so saying "invalid
       // request" and stopping would be true and useless.
       return {
-        heading: 'This connection needs to be set up again',
+        heading: 'Your client is holding a sign-in that no longer works',
         message:
-          'The address your app asked us to send you back to is not the one it registered. ' +
-          'That usually means the app was reinstalled or restarted on a different port. ' +
-          'Re-adding the InsForge MCP server with the command below fixes it.',
+          'The address your app asked us to send you back to is not the one it registered — ' +
+          'usually because it restarted on a different port. Clearing the saved authorisation is ' +
+          'what fixes it. In Claude Code: run /mcp, pick this server, and choose Clear ' +
+          'authentication. In Codex: run the first command below. Then reconnect with the last.',
         action: reconnectCommand(mcpUrl),
       };
 


### PR DESCRIPTION
Blair ran #84's printed commands as a stuck user instead of reasoning about them, and answered the question left open in that very file — *"whether removing the config entry also drops the client's saved OAuth registration is client-specific"*.

**For Claude Code it does not.** The saved authorisation lives in `mcpOAuth` under `name|sha256(type,url,headers)`, a store `add-mcp` never touches. Removing and re-adding the **same** url rebuilds the identical key and picks the dead registration straight back up.

Which makes the merged page wrong where it mattered most:

> …add it back with the command below, and **this will complete normally**.

On an unchanged hostname that is false for Claude Code, and it was aimed at exactly the population it would fail. A page that hands someone a confident non-fix is worse than one that says nothing, because they stop looking.

## What actually works

```
Claude Code   /mcp -> pick the server -> Clear authentication   (a UI action)
Codex         codex mcp logout insforge
```

The Claude Code step is not a command, so it belongs in the sentence rather than in a code block someone would try to paste. Codex's is real and joins the list **first**, because order is the instruction.

On a **new** hostname the remove/add pair does repair by itself — different url, different key, no saved state — so all three are printed and the wording no longer claims more than any of them can deliver.

## Rendered

```
Your client is holding a sign-in that no longer works

…it will keep reusing it until you clear it. In Claude Code: run /mcp, pick
this server, and choose Clear authentication. In Codex: run the first command
below. Then reconnect with the last one.

1. codex mcp logout insforge
2. npx add-mcp remove https://mcp.insforge.dev/mcp -y
3. npx add-mcp https://mcp.insforge.dev/mcp
```

Zero occurrences of the old promise. A test now **forbids** `complete normally` and **requires** the Clear authentication step, so the claim cannot quietly come back.

## Still unverified, stated rather than implied

Nobody has watched a real Claude Code reuse that record against a live server. Blair proved the record survives the commands; the reuse is inferred from how the key is derived. That remains Quinn's one-step editor test.

189 tests.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the OAuth error page to stop promising a reconnect that doesn’t work and adds clear steps to reset saved auth, especially for Claude Code. Improves reliability by updating command order and adding tests to prevent regressions.

- **Bug Fixes**
  - Updated error copy to tell users to clear saved authentication (Claude Code: use /mcp → Clear authentication; Codex: `codex mcp logout insforge`).
  - Changed `reconnectCommand(mcpUrl)` to return three steps: `codex mcp logout insforge`, `npx add-mcp remove <url> -y`, then `npx add-mcp <url>`.
  - Removed the “complete normally” promise and clarified behavior on same vs new hostnames.
  - Strengthened tests to assert the new text, command order, and correct host usage.

<sup>Written for commit 2e45e7d31d64767b54592a91d1c09ac71796e65d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/insforge-mcp/pull/90?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

