### PR TITLE
Authorization codes carry their own record, and PKCE becomes required

### DIFF
--- a/src/http/auth-state.test.ts
+++ b/src/http/auth-state.test.ts
@@ -133,3 +133,42 @@ describe(`a wrong key is our fault, not the caller's`, () => {
     }
   });
 });
+
+describe('the TTL is per-value, because a code is not a state', () => {
+  const KEY2 = deriveAuthStateKey('another-secret');
+  const T0 = 1_700_000_000_000;
+
+  it('honours a shorter TTL than the default', () => {
+    // RFC 6749 §4.1.2 wants an authorization code short-lived, and a code that
+    // cannot be single-use (nothing to delete) wants it more. Five minutes for
+    // codes, ten for state.
+    const sealed = sealAuthState({ code: true }, KEY2, T0, 5 * 60);
+    expect(openAuthState(sealed, KEY2, T0 + 5 * 60 * 1000 - 1)).toEqual({ code: true });
+    expect(() => openAuthState(sealed, KEY2, T0 + 5 * 60 * 1000)).toThrow(InvalidAuthStateError);
+  });
+
+  it('still defaults to the state TTL when none is given', () => {
+    const sealed = sealAuthState({ state: true }, KEY2, T0);
+    expect(openAuthState(sealed, KEY2, T0 + AUTH_STATE_TTL_SECONDS * 1000 - 1)).toEqual({ state: true });
+    expect(() => openAuthState(sealed, KEY2, T0 + AUTH_STATE_TTL_SECONDS * 1000)).toThrow();
+  });
+});
+
+describe('three purposes, three keys', () => {
+  it(`gives each label a key that rejects the other's output`, async () => {
+    const { deriveAuthCodeKey } = await import('./config.js');
+    const secret = 'one-secret-three-purposes';
+    const stateKey = deriveAuthStateKey(secret);
+    const codeKey = deriveAuthCodeKey(secret);
+
+    expect(stateKey.equals(codeKey)).toBe(false);
+    // An auth code must not be openable as an auth state, or a weakness in the
+    // most exposed value reaches the other.
+    expect(() => openAuthState(sealAuthState({ x: 1 }, codeKey), stateKey)).toThrow(
+      InvalidAuthStateError
+    );
+    expect(() => openAuthState(sealAuthState({ x: 1 }, stateKey), codeKey)).toThrow(
+      InvalidAuthStateError
+    );
+  });
+});

--- a/src/http/auth-state.ts
+++ b/src/http/auth-state.ts
@@ -57,12 +57,17 @@ const TAG_BYTES = 16;
  * covered by the authentication tag and cannot be extended by an attacker who
  * holds the blob.
  */
-export function sealAuthState<T>(value: T, key: Buffer, nowMs: number = Date.now()): string {
+export function sealAuthState<T>(
+  value: T,
+  key: Buffer,
+  nowMs: number = Date.now(),
+  ttlSeconds: number = AUTH_STATE_TTL_SECONDS
+): string {
   assertKey(key);
 
   const payload = JSON.stringify({
     v: value,
-    exp: nowMs + AUTH_STATE_TTL_SECONDS * 1000,
+    exp: nowMs + ttlSeconds * 1000,
   });
 
   const nonce = randomBytes(NONCE_BYTES);

--- a/src/http/config.ts
+++ b/src/http/config.ts
@@ -179,6 +179,28 @@ export function authStateKey(): Buffer {
   return deriveAuthStateKey(INSFORGE_CONFIG.clientSecret);
 }
 
+/**
+ * And a third key, for authorization codes. Same secret, third label.
+ *
+ * Three purposes, three keys, no relationship between them: a client id is
+ * public and signed, an auth state is secret and encrypted, an auth code is a
+ * bearer credential in its own right. Sharing one key across all three would
+ * mean a weakness in the most exposed use reaches the other two.
+ */
+const AUTH_CODE_KEY_LABEL = 'mcp-auth-code-v1';
+
+export function deriveAuthCodeKey(clientSecret: string): Buffer {
+  if (!clientSecret) {
+    throw new Error('INSFORGE_CLIENT_SECRET is required: the authorization code key is derived from it');
+  }
+  return createHmac('sha256', clientSecret).update(AUTH_CODE_KEY_LABEL).digest();
+}
+
+/** Lazy for the same reason as the others. */
+export function authCodeKey(): Buffer {
+  return deriveAuthCodeKey(INSFORGE_CONFIG.clientSecret);
+}
+
 // ============================================================================
 // Redis Configuration
 // ============================================================================

--- a/src/http/oauth-manager.ts
+++ b/src/http/oauth-manager.ts
@@ -2,7 +2,7 @@ import { createHash, randomBytes } from 'crypto';
 import { getRedisClient } from './redis.js';
 import { sealAuthState, openAuthState, InvalidAuthStateError } from './auth-state.js';
 import { newStateHandle } from './auth-state-cookie.js';
-import { authStateKey } from './config.js';
+import { authStateKey, authCodeKey } from './config.js';
 import {
   validateToken,
   getProjectAccess,
@@ -103,7 +103,6 @@ interface TokenBinding {
 
 // Redis key prefixes
 const TOKEN_BINDING_PREFIX = 'mcp:auth:binding:';
-const AUTH_CODE_PREFIX = 'mcp:auth:code:';
 
 // TTLs
 const AUTH_CODE_TTL = 5 * 60; // 5 minutes
@@ -252,18 +251,39 @@ export class OAuthManager {
       JSON.stringify(binding)
     );
 
-    // Create authorization code that references the token hash
-    const code = generateCode();
-    await redis.setex(
-      AUTH_CODE_PREFIX + code,
-      AUTH_CODE_TTL,
-      JSON.stringify({
+    // PKCE is REQUIRED for a sealed code, and this is the one place the
+    // stateless rewrite genuinely tightens behaviour rather than preserving it.
+    //
+    // GETDEL made the stored code single-use: redeemed once, gone. A sealed
+    // code cannot be single-use — there is nothing to delete — so it is
+    // replayable for its lifetime. What makes that acceptable is PKCE: a
+    // replayed code without the verifier is useless, and the verifier never
+    // leaves the client. Without PKCE a replay is a full second session, so the
+    // honest choice is to refuse rather than to issue a code we cannot protect.
+    //
+    // Nothing real is lost. The MCP spec requires PKCE of public clients, the
+    // SDK always sends it, and our AS metadata already advertises S256 as the
+    // only supported method — so this refuses a combination we never told
+    // anyone we would accept.
+    if (!authState.codeChallenge) {
+      throw new Error(
+        'PKCE is required: this server issues authorization codes that carry their own ' +
+          'state, and the code_challenge is what stops a replayed code from being redeemed.'
+      );
+    }
+
+    // The code IS the record. Five minutes, not the state's ten: RFC 6749
+    // §4.1.2 wants a code short-lived, and a replayable one wants it more.
+    const code = sealAuthState(
+      {
         tokenHash,
-        stateId,
         redirectUri: authState.redirectUri,
         codeChallenge: authState.codeChallenge,
         codeChallengeMethod: authState.codeChallengeMethod,
-      })
+      },
+      authCodeKey(),
+      Date.now(),
+      AUTH_CODE_TTL
     );
 
     // Nothing to clean up: the state was never stored. It stops being accepted
@@ -289,26 +309,33 @@ export class OAuthManager {
     redirectUri: string,
     codeVerifier?: string
   ): Promise<{ tokenHash: string }> {
-    const redis = getRedisClient();
-
-    // Atomically get and delete the code to prevent replay attacks
-    // GETDEL returns the value and deletes the key in one operation
-    const codeData = await redis.getdel(AUTH_CODE_PREFIX + code);
-
-    if (!codeData) {
+    // No GETDEL, because there is nothing stored. Replay is bounded by PKCE
+    // (required at issue time) and by the five-minute expiry sealed inside.
+    let payload: {
+      tokenHash: string;
+      redirectUri: string;
+      codeChallenge?: string;
+      codeChallengeMethod?: string;
+    };
+    try {
+      payload = openAuthState(code, authCodeKey());
+    } catch {
       throw new Error('Invalid or expired authorization code');
     }
 
-    const { tokenHash, redirectUri: storedRedirectUri, codeChallenge, codeChallengeMethod } =
-      JSON.parse(codeData);
+    const { tokenHash, redirectUri: storedRedirectUri, codeChallenge, codeChallengeMethod } = payload;
 
     // Validate redirect URI
     if (redirectUri !== storedRedirectUri) {
       throw new Error('Redirect URI mismatch');
     }
 
-    // Validate PKCE if code challenge was provided during authorization
-    if (codeChallenge) {
+    // Unconditional now: a code without a challenge cannot be issued, so one
+    // arriving without it is not ours to honour.
+    if (!codeChallenge) {
+      throw new Error('Authorization code is missing its code challenge');
+    }
+    {
       if (!codeVerifier) {
         throw new Error('Code verifier required');
       }


### PR DESCRIPTION
Fourth of five. `mcp:auth:code:` is gone; `oauth-manager`'s only remaining Redis use is the token binding.

## The one place this rewrite tightens behaviour

`GETDEL` made a stored code **single-use**: redeemed once, gone. A sealed code cannot be single-use — there is nothing to delete — so it is **replayable for its lifetime**.

What makes that acceptable is PKCE: a replayed code without the verifier is useless, and the verifier never leaves the client. **Without PKCE a replay is a full second session**, so the honest choice is to refuse at issue time rather than hand out a code we cannot protect.

Nothing real is lost by requiring it. The MCP spec requires PKCE of public clients, the SDK always sends it, and our AS metadata already advertises S256 as the *only* supported method — so this refuses a combination we never told anyone we would accept.

## Measured, including the part that is a genuine loosening

```
correct verifier             ok     {"tokenHash":"th"}
REPLAY, correct verifier     ok     <- replayable, as documented
no verifier                  THROW  Code verifier required
wrong verifier               THROW  Code verifier mismatch
wrong redirect_uri           THROW  Redirect URI mismatch
garbage code                 THROW  Invalid or expired authorization code
code with no challenge       THROW  Authorization code is missing its challenge

sealed code length           275 chars
```

The replay line is in the table on purpose. It is the cost of the change and it should be visible in review, not buried in a comment.

## Smaller things

- **Five minutes, not the state's ten.** RFC 6749 §4.1.2 wants a code short-lived, and one that cannot be single-use wants it more. `sealAuthState` takes a TTL per value now instead of assuming one.
- **A third derived key, third label.** Three purposes with no computable relationship between their keys: a client id is public and signed, an auth state is secret and encrypted, an auth code is a bearer credential in its own right. A test asserts each key rejects the others' output.

## Remaining

`mcp:auth:binding:` — the last one, and the one that needs the token to become self-describing rather than a Redis key. Until it lands a login still cannot complete.

210 tests.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Authorization codes are now stateless, sealed records with a 5-minute TTL, and PKCE is required to redeem them. Redis `mcp:auth:code:` storage is removed; only `mcp:auth:binding:` remains.

- **Refactors**
  - Replace stored codes with sealed payloads; TTL is per value (5 minutes for codes).
  - Enforce PKCE at issue and redeem; codes without a challenge are rejected.
  - Add a dedicated auth code key derived from the client secret; keys for client ID, state, and code are isolated.
  - Redeem path opens the sealed code, validates redirect URI, and verifies the code verifier; replay limited by PKCE and expiry.

- **Migration**
  - No client changes needed; SDKs already send PKCE and the AS advertises `S256` only.

<sup>Written for commit c044d3c81d29d4e00ab67c958528b16193d0a88b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/insforge-mcp/pull/91?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

