### PR TITLE
A co-tenant could substitute or kill our state cookie

### DIFF
--- a/src/http/auth-state-cookie.test.ts
+++ b/src/http/auth-state-cookie.test.ts
@@ -1,8 +1,9 @@
 import { describe, it, expect } from 'vitest';
 import {
   AUTH_STATE_COOKIE,
+  authStateCookieName,
   cookieAttributes,
-  readCookie,
+  readCookies,
   newStateHandle,
   isAcceptableClientState,
   MAX_CLIENT_STATE_LENGTH,
@@ -35,10 +36,8 @@ describe('cookie attributes', () => {
     expect(cookieAttributes('https://mcp.insforge.dev').sameSite).toBe('lax');
   });
 
-  it('is HttpOnly and scoped to the OAuth routes', () => {
-    const attrs = cookieAttributes('https://mcp.insforge.dev');
-    expect(attrs.httpOnly).toBe(true);
-    expect(attrs.path).toBe('/oauth');
+  it('is HttpOnly', () => {
+    expect(cookieAttributes('https://mcp.insforge.dev').httpOnly).toBe(true);
   });
 
   it('follows the public URL for Secure rather than hardcoding it', () => {
@@ -50,28 +49,70 @@ describe('cookie attributes', () => {
   });
 });
 
-describe('readCookie', () => {
+describe('the cookie name a co-tenant cannot set', () => {
+  it('uses __Host- wherever there is TLS', () => {
+    // *.run.mcp-use.com is a shared parent domain with our own insta-mcp
+    // servers as neighbours. Any co-tenant can set a Domain cookie of any name
+    // for the parent; __Host- is the only mechanism that stops it, because a
+    // browser refuses to store one unless it is Secure, Path=/ and has no
+    // Domain — which together mean only the exact host can set it.
+    expect(authStateCookieName('https://keen-pulse-fsjr9.run.mcp-use.com')).toBe(
+      '__Host-mcp_oauth_state'
+    );
+  });
+
+  it('falls back only when there is no TLS at all', () => {
+    // __Host- requires Secure and a Secure cookie is dropped on plaintext
+    // http, which is local development and nothing else.
+    expect(authStateCookieName('http://127.0.0.1:3000')).toBe('mcp_oauth_state');
+  });
+
+  it('takes Path=/ , which __Host- requires and which costs nothing', () => {
+    // A cookie path was never a security boundary: any path on a host can read
+    // or set that host's cookies. The prefix buys a guarantee the path did not.
+    expect(cookieAttributes('https://mcp.insforge.dev').path).toBe('/');
+  });
+});
+
+describe('readCookies survives a hostile neighbour', () => {
+  const N = AUTH_STATE_COOKIE;
+  const ours = 'v1.OURS';
+
   it('finds the value among others', () => {
-    expect(readCookie(`a=1; ${AUTH_STATE_COOKIE}=v1.abc; b=2`, AUTH_STATE_COOKIE)).toBe('v1.abc');
+    expect(readCookies(`a=1; ${N}=v1.abc; b=2`, N)).toEqual(['v1.abc']);
   });
 
   it('percent-decodes, because that is how it was written', () => {
-    expect(readCookie(`${AUTH_STATE_COOKIE}=v1.a%2Bb%3D`, AUTH_STATE_COOKIE)).toBe('v1.a+b=');
+    expect(readCookies(`${N}=v1.a%2Bb%3D`, N)).toEqual(['v1.a+b=']);
+  });
+
+  it('returns EVERY match, so a shadowing cookie cannot substitute itself', () => {
+    // Measured on the shipped version: taking the first match meant a
+    // co-tenant's value was read INSTEAD of ours. Returning all of them makes
+    // shadowing inert, because a shadowing value simply fails to decrypt and
+    // the caller tries the next.
+    expect(readCookies(`${N}=v1.ATTACKER; ${N}=${ours}`, N)).toEqual(['v1.ATTACKER', ours]);
+    expect(readCookies(`${N}=${ours}; ${N}=v1.ATTACKER`, N)).toEqual([ours, 'v1.ATTACKER']);
+  });
+
+  it('skips a malformed value and keeps looking', () => {
+    // The worse of the two: the old code RETURNED on a decode error, so one
+    // bad percent-escape from a neighbour was a permanent sign-in outage
+    // needing no crypto and no knowledge of our internals.
+    expect(readCookies(`${N}=%E0%A4%A; ${N}=${ours}`, N)).toEqual([ours]);
+    expect(readCookies(`${N}=${ours}; ${N}=%E0%A4%A`, N)).toEqual([ours]);
+    expect(readCookies(`${N}=%E0%A4%A`, N)).toEqual([]);
   });
 
   it('does not match a name that merely contains ours', () => {
-    expect(readCookie(`x_${AUTH_STATE_COOKIE}=nope`, AUTH_STATE_COOKIE)).toBeUndefined();
-    expect(readCookie(`${AUTH_STATE_COOKIE}_x=nope`, AUTH_STATE_COOKIE)).toBeUndefined();
-  });
-
-  it('treats a malformed value as absent rather than throwing mid-sign-in', () => {
-    expect(readCookie(`${AUTH_STATE_COOKIE}=%E0%A4%A`, AUTH_STATE_COOKIE)).toBeUndefined();
+    expect(readCookies(`x_${N}=nope`, N)).toEqual([]);
+    expect(readCookies(`${N}_x=nope`, N)).toEqual([]);
   });
 
   it('handles no header, an empty header and a valueless entry', () => {
-    expect(readCookie(undefined, AUTH_STATE_COOKIE)).toBeUndefined();
-    expect(readCookie('', AUTH_STATE_COOKIE)).toBeUndefined();
-    expect(readCookie('justaname', AUTH_STATE_COOKIE)).toBeUndefined();
+    expect(readCookies(undefined, N)).toEqual([]);
+    expect(readCookies('', N)).toEqual([]);
+    expect(readCookies('justaname', N)).toEqual([]);
   });
 });
 

--- a/src/http/auth-state-cookie.ts
+++ b/src/http/auth-state-cookie.ts
@@ -31,7 +31,33 @@ import { randomBytes } from 'crypto';
  * prevent.
  */
 
-/** The cookie carrying the sealed state. Scoped to the OAuth routes only. */
+/**
+ * The cookie carrying the sealed state.
+ *
+ * `__Host-` is not decoration. On a shared parent domain — which
+ * `*.run.mcp-use.com` is, with our own insta-mcp servers as neighbours — any
+ * co-tenant can set a Domain cookie of ANY name for the parent, and the browser
+ * sends it to us alongside our own. The prefix is the only mechanism that stops
+ * that: a browser refuses to store a `__Host-` cookie unless it has Secure, has
+ * Path=/, and has NO Domain attribute, which together mean only the exact host
+ * can set it.
+ *
+ * Path=/ rather than /oauth is the cost, and it is not a real one — cookie paths
+ * were never a security boundary; any path on a host can read or set the host's
+ * cookies. The prefix buys a guarantee, the path never did.
+ *
+ * The name falls back only when there is no TLS at all, because `__Host-`
+ * requires Secure and a Secure cookie is dropped on plaintext http. That is
+ * local development and nothing else — no deployment of this server runs
+ * without https — but it is a fallback, and fallbacks are how protections get
+ * lost, so it is keyed on the scheme rather than on an environment flag someone
+ * could set.
+ */
+export function authStateCookieName(publicUrl: string): string {
+  return publicUrl.startsWith('https://') ? '__Host-mcp_oauth_state' : 'mcp_oauth_state';
+}
+
+/** @deprecated Prefer authStateCookieName(publicUrl); kept for the http case. */
 export const AUTH_STATE_COOKIE = 'mcp_oauth_state';
 
 /**
@@ -73,40 +99,57 @@ export interface CookieAttributes {
  * runs on http://127.0.0.1. Hardcoding true makes every local run fail in a way
  * that looks like a code bug.
  */
-export function cookieAttributes(publicUrl: string, oauthPathPrefix = '/oauth'): CookieAttributes {
+export function cookieAttributes(publicUrl: string): CookieAttributes {
   return {
     httpOnly: true,
     secure: publicUrl.startsWith('https://'),
     sameSite: 'lax',
-    path: oauthPathPrefix,
+    // Path=/ is required by __Host-, and costs nothing: a cookie path has never
+    // been a security boundary. Any path on the host can read or set it.
+    path: '/',
     maxAge: AUTH_STATE_COOKIE_MAX_AGE_SECONDS * 1000,
   };
 }
 
 /**
- * Read one cookie out of a raw Cookie header.
+ * Read EVERY cookie with this name, not the first.
  *
- * Hand-rolled rather than adding cookie-parser: this reads exactly one name,
- * and a dependency whose whole job is `split('; ')` is a dependency to keep
- * patched forever. Values are percent-encoded on the way out, so decode here.
+ * The first version returned the first match and gave up on a decode error, and
+ * both of those were exploitable by a co-tenant on a shared parent domain.
+ * Measured on the shipped code rather than argued:
+ *
+ *   Cookie: NAME=v1.ATTACKER; NAME=<ours>   -> we read the attacker's
+ *   Cookie: NAME=%E0%A4%A;    NAME=<ours>   -> we read undefined, forever
+ *
+ * The second is the worse one: a single malformed percent-escape from a
+ * neighbour is a permanent sign-in outage needing no crypto, no timing and no
+ * knowledge of our internals. "Fails closed" was the wrong frame — the question
+ * is closed for WHOM, and it was closed for us and open for them.
+ *
+ * So: collect every candidate, skip the ones that will not decode, and let the
+ * caller try each. Shadowing becomes inert because a shadowing value simply
+ * fails to open and the next one is tried. This matters more than the
+ * `__Host-` prefix, because it survives someone dropping the prefix later —
+ * which is exactly how this class of bug comes back.
  */
-export function readCookie(header: string | undefined, name: string): string | undefined {
-  if (typeof header !== 'string' || header.length === 0) return undefined;
+export function readCookies(header: string | undefined, name: string): string[] {
+  if (typeof header !== 'string' || header.length === 0) return [];
 
+  const found: string[] = [];
   for (const part of header.split(';')) {
     const eq = part.indexOf('=');
     if (eq === -1) continue;
     if (part.slice(0, eq).trim() !== name) continue;
     const raw = part.slice(eq + 1).trim();
     try {
-      return decodeURIComponent(raw);
+      found.push(decodeURIComponent(raw));
     } catch {
-      // A malformed value is not ours; treat it as absent rather than throwing
-      // a decode error out of the middle of a sign-in.
-      return undefined;
+      // Not ours — ours is base64url and always decodes. CONTINUE rather than
+      // return: one bad neighbour must not end the search.
+      continue;
     }
   }
-  return undefined;
+  return found;
 }
 
 /**

--- a/src/http/server.ts
+++ b/src/http/server.ts
@@ -39,9 +39,9 @@ import {
   type ClientRegistration,
 } from './client-id.js';
 import {
-  AUTH_STATE_COOKIE,
+  authStateCookieName,
   cookieAttributes,
-  readCookie,
+  readCookies,
   isAcceptableClientState,
   MAX_CLIENT_STATE_LENGTH,
 } from './auth-state-cookie.js';
@@ -99,6 +99,28 @@ function isInitializeRequest(body: unknown): boolean {
   }
 
   return false;
+}
+
+/**
+ * The sealed state from the request, or null.
+ *
+ * Every cookie with our name is tried, not just the first. On a shared parent
+ * domain a co-tenant can set a cookie of any name for the parent and the
+ * browser sends it alongside ours; taking the first match let a neighbour
+ * either substitute their value or, with one malformed percent-escape, end
+ * every sign-in. A shadowing value simply fails to open here and the next
+ * candidate is tried.
+ */
+async function openStateFromRequest(
+  req: Request,
+  expectedHandle: string
+): Promise<{ sealed: string; authState: NonNullable<Awaited<ReturnType<ReturnType<typeof getOAuthManager>['getAuthorizationState']>>> } | null> {
+  const oauthManager = getOAuthManager();
+  for (const sealed of readCookies(req.headers.cookie, authStateCookieName(SERVER_CONFIG.publicUrl))) {
+    const authState = await oauthManager.getAuthorizationState(sealed, expectedHandle);
+    if (authState) return { sealed, authState };
+  }
+  return null;
 }
 
 /**
@@ -416,7 +438,7 @@ app.get(OAUTH_ENDPOINTS.authorize, async (req: Request, res: Response) => {
     authUrl.searchParams.set('scope', INSFORGE_CONFIG.oauthScopes);
     // The handle, not the record. The platform stores `state` in a 255-char
     // column; the record itself rides in a cookie on our own origin.
-    res.cookie(AUTH_STATE_COOKIE, sealedState, cookieAttributes(SERVER_CONFIG.publicUrl));
+    res.cookie(authStateCookieName(SERVER_CONFIG.publicUrl), sealedState, cookieAttributes(SERVER_CONFIG.publicUrl));
     authUrl.searchParams.set('state', handle);
     authUrl.searchParams.set('code_challenge', insforgeCodeChallenge);
     authUrl.searchParams.set('code_challenge_method', 'S256');
@@ -452,9 +474,7 @@ app.get(OAUTH_ENDPOINTS.callback, async (req: Request, res: Response) => {
       errorDescription: (error_description as string) || (error as string) || 'Unknown Insforge error',
       endpoint: '/oauth/callback',
     });
-    const sealed = readCookie(req.headers.cookie, AUTH_STATE_COOKIE);
-    const authState =
-      sealed && state ? await oauthManager.getAuthorizationState(sealed, state as string) : null;
+    const authState = state ? (await openStateFromRequest(req, state as string))?.authState ?? null : null;
 
     if (authState?.redirectUri) {
       const redirectUrl = new URL(authState.redirectUri);
@@ -501,10 +521,7 @@ app.get(OAUTH_ENDPOINTS.callback, async (req: Request, res: Response) => {
   try {
     // The record is in our cookie; the platform only echoes the handle. Both
     // are required, and they have to name the same authorization.
-    const sealed = readCookie(req.headers.cookie, AUTH_STATE_COOKIE);
-    const authState = sealed
-      ? await oauthManager.getAuthorizationState(sealed, state as string)
-      : null;
+    const authState = (await openStateFromRequest(req, state as string))?.authState ?? null;
     if (!authState) {
       getAnalyticsService().trackOAuthFailure({
         errorType: 'invalid_request',
@@ -583,7 +600,7 @@ app.get(OAUTH_ENDPOINTS.callback, async (req: Request, res: Response) => {
 
     // Same shape as authorize: the record replaces the cookie, the URL carries
     // only the handle. The handle is unchanged, so the two halves still match.
-    res.cookie(AUTH_STATE_COOKIE, stateWithToken, cookieAttributes(SERVER_CONFIG.publicUrl));
+    res.cookie(authStateCookieName(SERVER_CONFIG.publicUrl), stateWithToken, cookieAttributes(SERVER_CONFIG.publicUrl));
     res.redirect(
       `${SERVER_CONFIG.publicUrl}${OAUTH_ENDPOINTS.selectProject}?state_id=${encodeURIComponent(authState.handle)}`
     );
@@ -619,10 +636,7 @@ app.get(OAUTH_ENDPOINTS.selectProject, async (req: Request, res: Response) => {
   try {
     const oauthManager = getOAuthManager();
 
-    const sealed = readCookie(req.headers.cookie, AUTH_STATE_COOKIE);
-    const authState = sealed
-      ? await oauthManager.getAuthorizationState(sealed, state_id as string)
-      : null;
+    const authState = (await openStateFromRequest(req, state_id as string))?.authState ?? null;
     if (!authState) {
       return res.status(400).send('Session expired. Please start the authorization process again.');
     }
@@ -662,10 +676,9 @@ app.post(OAUTH_ENDPOINTS.selectProject, async (req: Request, res: Response) => {
   try {
     const oauthManager = getOAuthManager();
 
-    const sealed = readCookie(req.headers.cookie, AUTH_STATE_COOKIE);
-    const authState = sealed
-      ? await oauthManager.getAuthorizationState(sealed, state_id as string)
-      : null;
+    const opened = await openStateFromRequest(req, state_id as string);
+    const sealed = opened?.sealed;
+    const authState = opened?.authState ?? null;
     if (!sealed || !authState?.platformAccessToken) {
       return res.status(400).json({
         error: 'invalid_request',
@@ -685,7 +698,7 @@ app.post(OAUTH_ENDPOINTS.selectProject, async (req: Request, res: Response) => {
     // cookie. Clearing it on completion is cheap defence in depth: the sealed
     // state is replayable inside its ten minutes, and there is no reason to
     // leave a usable copy in the browser once the flow has finished.
-    res.clearCookie(AUTH_STATE_COOKIE, { path: '/oauth' });
+    res.clearCookie(authStateCookieName(SERVER_CONFIG.publicUrl), { path: '/' });
 
     const redirectUrl = new URL(authState.redirectUri);
     redirectUrl.searchParams.set('code', code);


### PR DESCRIPTION
Quinn found the class, Max verified it on master. I reproduced both against the shipped `readCookie` rather than taking either:

```
Cookie: NAME=v1.ATTACKER; NAME=<ours>   -> we read "v1.ATTACKER"
Cookie: NAME=%E0%A4%A;    NAME=<ours>   -> we read undefined, forever
```

**The second is the worse one and the cheaper one.** `catch { return undefined }` *returns* rather than continues, so a single malformed percent-escape in a neighbour's cookie is a permanent sign-in outage — no crypto, no timing, no knowledge of our internals. My comment claimed the read "fails closed"; it never asked closed **for whom**. Closed for us, open for them.

## Three fixes, in reverse order of how much they matter

```
read EVERY match              shadowing becomes inert — a shadowing value fails
                              to open and the next candidate is tried
malformed value: continue     one bad escape stops being fatal
__Host- prefix, Path=/        a browser refuses to store a __Host- cookie with a
                              Domain, so no co-tenant can set our name at all
```

The first two matter **more** than the prefix, because they survive someone dropping the prefix later — which is exactly how this class comes back.

## Measured after

```
attacker first             ["v1.ATTACKER","v1.OURS"]   ours reachable
attacker MALFORMED first   ["v1.OURS"]                 ours reachable
name on https              __Host-mcp_oauth_state
name on http               mcp_oauth_state
```

`Path=/` is what `__Host-` requires and it costs nothing: a cookie path was never a security boundary — any path on a host can read or set that host's cookies. The prefix buys a guarantee the path never did.

The name falls back **only** when there is no TLS at all, because `__Host-` requires Secure and a Secure cookie is dropped on plaintext http. That is local development and nothing else, and it is keyed on the scheme rather than on a flag someone could set — fallbacks are how protections get lost.

211 tests.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents co-tenants on shared domains from substituting or breaking our OAuth state cookie. We now use a `__Host-` cookie on TLS and read all candidate cookies, skipping malformed values, so our state stays reachable.

- **Bug Fixes**
  - Use `authStateCookieName()` to set `__Host-mcp_oauth_state` on HTTPS (fallback to `mcp_oauth_state` only on plain HTTP). Path=/, HttpOnly; Secure follows the public URL.
  - Replace `readCookie` with `readCookies` to collect all matches and continue on decode errors; callers try each candidate.
  - Update server flows to use `openStateFromRequest()` and to set/clear the correct cookie name and attributes.

<sup>Written for commit 6c980888e5fc76f8b72944faa8ce19d49b0277be. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/insforge-mcp/pull/92?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

