### PR TITLE
Refuse a missing code_challenge at authorize, not at the end

### DIFF
--- a/src/http/server.ts
+++ b/src/http/server.ts
@@ -343,6 +343,29 @@ app.get(OAUTH_ENDPOINTS.authorize, async (req: Request, res: Response) => {
     });
   }
 
+  if (!code_challenge) {
+    // Refused HERE, not at the end.
+    //
+    // #91 made authorization codes stateless, which means they cannot be
+    // single-use, which means PKCE is what stops a replay. I put the refusal in
+    // createAuthorizationCode — and measured on the slug that a client without
+    // PKCE still gets a 302, signs in through the browser, picks a project, and
+    // only THEN fails. The person did all the work before we told them we were
+    // never going to accept it.
+    //
+    // That is the same mistake as validating a redirect_uri at authorize
+    // instead of at registration: reject where the caller is listening, not
+    // where only a browser can see it. The MCP client reads this response; it
+    // never reads the one at the end of the flow.
+    return sendOAuthError(req, res, 400, {
+      error: 'invalid_request',
+      error_description:
+        'code_challenge is required. This server advertises S256 as its only ' +
+        'code_challenge_method and issues authorization codes that carry their own state, ' +
+        'so PKCE is what makes a code safe to accept.',
+    });
+  }
+
   if (response_type !== 'code') {
     return sendOAuthError(req, res, 400, {
       error: 'unsupported_response_type',


### PR DESCRIPTION
#91 required PKCE — and put the refusal in `createAuthorizationCode`, which runs **after** the browser sign-in and the project picker. Measured on the slug once it deployed:

```
authorize with no code_challenge  ->  302
```

So a client without PKCE gets redirected, the person signs in, chooses a project, and *only then* hits the refusal. They did all of the work before we told them we were never going to accept it.

Same mistake as validating a `redirect_uri` at authorize instead of at registration: **reject where the caller is listening**, not where only a browser can see it. The MCP client reads the authorize response; nothing reads the one at the end of the flow.

```
no code_challenge     400  invalid_request, naming code_challenge
with code_challenge   302
```

The error says *why* rather than just *what*: we advertise S256 as our only `code_challenge_method` and issue codes that carry their own state, so PKCE is what makes a code safe to accept.

211 tests.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reject authorize requests missing a PKCE `code_challenge` at the authorize endpoint so clients get an immediate, actionable error. This prevents users from completing sign-in and project selection only to be rejected at the end.

- **Bug Fixes**
  - Validate `code_challenge` in the authorize handler; missing now returns 400 `invalid_request` with a clear message.
  - With `code_challenge`: unchanged (302).

<sup>Written for commit 022db38727b55a2451c0934726ae348167154eca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/insforge-mcp/pull/93?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

