### PR TITLE
The token stops being a Redis key: `mcp:auth:binding:` cutover

### DIFF
--- a/src/http/access-token.test.ts
+++ b/src/http/access-token.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect } from 'vitest';
+import { createHmac } from 'crypto';
+import {
+  issueAccessToken,
+  readAccessToken,
+  ACCESS_TOKEN_TTL_SECONDS,
+  MAX_ACCESS_TOKEN_LENGTH,
+  type AccessTokenPayload,
+} from './access-token.js';
+import { deriveAuthStateKey } from './config.js';
+
+/**
+ * The most valuable envelope we issue, and it shipped without a test file.
+ * That is the gap this closes — the fields it carries were argued about in
+ * review and pinned nowhere.
+ */
+
+const key = createHmac('sha256', 'a-test-secret').update('mcp-access-token-v1').digest();
+const otherKey = createHmac('sha256', 'a-different-secret').update('mcp-access-token-v1').digest();
+const T0 = 1_700_000_000_000;
+
+const payload: AccessTokenPayload = {
+  userId: 'user_1',
+  platformAccessToken: 'eyJ.a-platform-jwt.sig',
+  projectId: 'proj_1',
+};
+
+describe('the access token', () => {
+  it('comes back as what went in', () => {
+    const token = issueAccessToken(payload, key, T0);
+    expect(readAccessToken(token, key, T0)).toEqual(payload);
+  });
+
+  it('carries ONLY platform-issued, bounded fields', () => {
+    // The test Max's finding earns. `projectName` was in here, a project name
+    // is `z.string().min(2)` upstream with no `.max`, and it rode inside every
+    // token issued for that project — so one org member's 10k-character name
+    // minted an unusable token for every other member.
+    //
+    // Asserting the exact key set rather than the absence of one name: the
+    // defect was a class (caller-influenced data in a credential), and
+    // `organizationId`, `accessHost` and `userEmail` were in the same class,
+    // three of them read from the payload by nothing at all.
+    const token = issueAccessToken(payload, key, T0);
+    const opened = readAccessToken(token, key, T0)!;
+    expect(Object.keys(opened).sort()).toEqual(['platformAccessToken', 'projectId', 'userId']);
+  });
+
+  it('refuses to issue a token no proxy would carry', () => {
+    // The belt. Bounded by construction is what the payload is FOR, so this
+    // should never fire in production — it fires when someone adds a field that
+    // is not bounded, which is precisely the mistake that has now been made
+    // three times in one day on three different envelopes.
+    const huge = { ...payload, platformAccessToken: 'x'.repeat(MAX_ACCESS_TOKEN_LENGTH) };
+    expect(() => issueAccessToken(huge, key, T0)).toThrow(/Refusing to issue an access token/);
+  });
+
+  it('does not print the payload when it refuses', () => {
+    // A length is enough to act on. This message reaches logs.
+    const secret = 'super-secret-platform-token-'.repeat(200);
+    try {
+      issueAccessToken({ ...payload, platformAccessToken: secret }, key, T0);
+      throw new Error('expected a refusal');
+    } catch (error) {
+      expect((error as Error).message).not.toContain(secret);
+      expect((error as Error).message).toMatch(/limit 4096/);
+    }
+  });
+
+  it('leaves realistic room: a real token is far under the cap', () => {
+    // If this ever gets close, the cap is doing nothing and the number needs
+    // re-deriving from a fresh measurement of the chain, not raising.
+    const token = issueAccessToken(payload, key, T0);
+    expect(token.length).toBeLessThan(MAX_ACCESS_TOKEN_LENGTH / 2);
+  });
+
+  it('is null, never a throw, for anything that is not ours', () => {
+    // Every caller treats "not our token" as an ordinary 401, and #95 is what
+    // happens when one of these paths throws instead: a 500 with no
+    // WWW-Authenticate, which tells an MCP client to give up rather than to
+    // sign in again.
+    expect(readAccessToken('', key, T0)).toBeNull();
+    expect(readAccessToken('not-a-token', key, T0)).toBeNull();
+    expect(readAccessToken('v1.STALE_FROM_AN_EARLIER_FORMAT', key, T0)).toBeNull();
+    expect(readAccessToken('v2.' + 'A'.repeat(80), key, T0)).toBeNull();
+  });
+
+  it('is null under a different key, so rotation signs everyone out', () => {
+    // The stated and only revocation mechanism for the sealed values: rotating
+    // INSFORGE_CLIENT_SECRET. Worth a test because it is also the operational
+    // cost Max flagged — client ids, auth states and access tokens all die at
+    // once.
+    const token = issueAccessToken(payload, key, T0);
+    expect(readAccessToken(token, otherKey, T0)).toBeNull();
+  });
+
+  it('is null once tampered with', () => {
+    const token = issueAccessToken(payload, key, T0);
+    const flipped = token.slice(0, -1) + (token.endsWith('A') ? 'B' : 'A');
+    expect(readAccessToken(flipped, key, T0)).toBeNull();
+  });
+
+  it('expires 24 hours out, not 30 days', () => {
+    // The binding it replaced lived 30 days and refreshed on use. A value that
+    // cannot be revoked directly should not live for a month — the TTL IS the
+    // revocation window for the token itself, so a shortening here is a
+    // security property and a lengthening needs an argument.
+    const token = issueAccessToken(payload, key, T0);
+    const ttlMs = ACCESS_TOKEN_TTL_SECONDS * 1000;
+    expect(readAccessToken(token, key, T0 + ttlMs - 1)).toEqual(payload);
+    expect(readAccessToken(token, key, T0 + ttlMs)).toBeNull();
+    expect(ACCESS_TOKEN_TTL_SECONDS).toBe(24 * 60 * 60);
+  });
+
+  it('is sealed, not signed: the platform token is not readable from it', () => {
+    // The reason this is AES-GCM and a client id is an HMAC. A
+    // signed-but-readable bearer would publish a platform credential to anyone
+    // who saw the header — including our own logs.
+    const token = issueAccessToken(payload, key, T0);
+    const body = Buffer.from(token.slice('v1.'.length), 'base64url').toString('utf8');
+    expect(token).not.toContain(payload.platformAccessToken);
+    expect(body).not.toContain(payload.platformAccessToken);
+    expect(body).not.toContain('proj_1');
+  });
+
+  it('uses a key that is not the auth-state key', () => {
+    // Same secret, different label. A token sealed for one purpose must not
+    // open under another, or the domain separation is decorative.
+    const token = issueAccessToken(payload, key, T0);
+    expect(readAccessToken(token, deriveAuthStateKey('a-test-secret'), T0)).toBeNull();
+  });
+});

--- a/src/http/access-token.ts
+++ b/src/http/access-token.ts
@@ -1,0 +1,86 @@
+import { sealAuthState, openAuthState, InvalidAuthStateError } from './auth-state.js';
+
+/**
+ * The access token we hand an MCP client, as a value rather than a Redis key.
+ *
+ * Until now our bearer was literally a lookup key: `resolveProjectFromToken`
+ * took it, read `mcp:auth:binding:<token>`, and got back everything that gave
+ * it meaning. The token said nothing. Delete the store and every issued token
+ * became a meaningless string — not because OAuth was missing, but because we
+ * never put anything IN the token. That is why a restart signed everyone out,
+ * and it is the last thing keeping Redis alive.
+ *
+ * So carry it. Encrypted, not signed, and for a stronger reason than the auth
+ * state: this envelope holds the PLATFORM access token. A signed-but-readable
+ * bearer would publish a platform credential to anyone who saw the header.
+ *
+ * WHAT IS DELIBERATELY NOT IN HERE: the project's API key. It is a credential
+ * with its own lifetime, and sealing it would freeze it for the token's whole
+ * life — so a rotated or revoked project key would keep working. It is fetched
+ * per request instead, from a cache with a short fixed TTL. See
+ * project-key-cache.ts for why the TTL is fixed rather than bounded by `exp`.
+ *
+ * REVOCATION MOVES TO THE PLATFORM, and that is the trade to understand. The
+ * binding row could be deleted; a sealed token cannot. What replaces it is the
+ * platform's own revocation — `validateAccessToken` checks `revoked` on every
+ * call — which is where revocation was really enforced all along. The bound on
+ * how stale that can be is the project-key cache TTL, which is why it is 60
+ * seconds and not "until exp".
+ */
+
+export interface AccessTokenPayload {
+  /** Who this is, from the platform at login. */
+  userId: string;
+  userEmail: string;
+
+  /**
+   * The platform access token.
+   *
+   * This is what makes the MCP able to act as the user without storing
+   * anything — and what makes this envelope the most valuable thing we issue.
+   * It is also what lets platform-level tools (list/create/switch project)
+   * exist at all: they need this, not a project key.
+   */
+  platformAccessToken: string;
+
+  /** The project chosen at sign-in. A per-call or per-URL project replaces
+   *  this later; it is here now so nothing else has to change at once. */
+  projectId: string;
+  projectName: string;
+  organizationId: string;
+  accessHost: string;
+}
+
+/**
+ * How long an issued token is accepted.
+ *
+ * The binding it replaces used 30 days, refreshed on use. This is deliberately
+ * shorter: a value that cannot be revoked directly should not live for a month.
+ * The platform token inside has its own expiry too, and whichever runs out
+ * first ends the session — which is the safe direction.
+ */
+export const ACCESS_TOKEN_TTL_SECONDS = 24 * 60 * 60;
+
+export function issueAccessToken(
+  payload: AccessTokenPayload,
+  key: Buffer,
+  nowMs: number = Date.now()
+): string {
+  return sealAuthState(payload, key, nowMs, ACCESS_TOKEN_TTL_SECONDS);
+}
+
+/**
+ * Recover the payload, or null.
+ *
+ * Null rather than a throw because every caller treats "not our token" as an
+ * ordinary 401 — an expired sign-in is the common case here, not an attack,
+ * and a caller that could tell the two apart would be an oracle.
+ */
+export function readAccessToken(token: string, key: Buffer, nowMs: number = Date.now()): AccessTokenPayload | null {
+  try {
+    return openAuthState<AccessTokenPayload>(token, key, nowMs);
+  } catch (error) {
+    if (error instanceof InvalidAuthStateError) return null;
+    throw error;
+  }
+}

--- a/src/http/access-token.ts
+++ b/src/http/access-token.ts
@@ -28,10 +28,43 @@ import { sealAuthState, openAuthState, InvalidAuthStateError } from './auth-stat
  * seconds and not "until exp".
  */
 
+/**
+ * EVERY FIELD IN HERE IS PLATFORM-ISSUED AND BOUNDED. That is a property to
+ * preserve, not a coincidence, and it was not true when this file was first
+ * written.
+ *
+ * The first version also carried `projectName`, `organizationId`, `accessHost`
+ * and `userEmail`. Max found the hole in `projectName`: cloud-backend's
+ * `createProjectSchema` is `z.string().trim().min(2)` — a `.min` with no
+ * `.max` — so a project name is unbounded, and it rode inside every token
+ * issued for that project. A 10k-character name mints a token no
+ * `Authorization` header will carry, and the person who breaks it need not be
+ * the person who named it: one org member names the project, every member who
+ * selects it gets an unusable token.
+ *
+ * Dropping it cost nothing, which is the part worth recording. Those four
+ * fields were WRITTEN here and read almost nowhere:
+ *
+ *   projectName · organizationId · accessHost   re-fetched by
+ *                                               resolveProjectFromToken anyway,
+ *                                               which reads them off the
+ *                                               project-key cache, never off
+ *                                               the payload
+ *   userEmail                                   written at issue, read by
+ *                                               nothing at all
+ *
+ * So the seal was carrying four values for the benefit of one informational
+ * field in one endpoint's response body. Same reasoning as keeping the project
+ * API key out: display data that can be re-fetched does not belong in a
+ * credential.
+ *
+ * The rule for anyone adding a field: it must be platform-issued and bounded,
+ * or it does not go in. A caller-influenced string in here is a denial of
+ * service against everyone who shares the resource it names.
+ */
 export interface AccessTokenPayload {
   /** Who this is, from the platform at login. */
   userId: string;
-  userEmail: string;
 
   /**
    * The platform access token.
@@ -46,9 +79,6 @@ export interface AccessTokenPayload {
   /** The project chosen at sign-in. A per-call or per-URL project replaces
    *  this later; it is here now so nothing else has to change at once. */
   projectId: string;
-  projectName: string;
-  organizationId: string;
-  accessHost: string;
 }
 
 /**
@@ -61,12 +91,58 @@ export interface AccessTokenPayload {
  */
 export const ACCESS_TOKEN_TTL_SECONDS = 24 * 60 * 60;
 
+/**
+ * The longest token we will hand out — the belt to go with the braces above.
+ *
+ * The payload is bounded by construction now, so this should never fire. It
+ * exists because that sentence has been wrong three times today: a client id, a
+ * sealed state and this token were each "bounded" until a field turned out not
+ * to be. The one remaining variable-length value in here is the platform's own
+ * access token, which is not ours to bound.
+ *
+ * The number comes from measurements rather than from a round constant. Iris
+ * drove the real chain — Cloudflare, the Fly proxy, Node's 16KB default — with
+ * a synthetic bearer, and the rest is this seal measured directly:
+ *
+ *   15512 chars   accepted by the whole chain
+ *   15573 chars   431 Request Header Fields Too Large
+ *    1483 chars   what the old payload minted
+ *   ~1250 chars   what this payload mints (the four dropped fields cost 233)
+ *
+ * So 4096 is ~3.3x the real token, and it is reached when the PLATFORM's own
+ * token passes ~2950 characters — roughly 3.8x its size today. Far enough away
+ * that tripping this means something changed that someone should look at, and
+ * far enough below 15512 that the refusal happens here, where it is explained,
+ * rather than at a proxy that will not say why.
+ *
+ * It THROWS rather than truncating or warning, and the failure lands at
+ * sign-in: the callback's error handler turns it into the OAuth error page, so
+ * a person sees "something went wrong on our side" at the moment it went wrong.
+ * The alternative is worse in the way that is hard to debug — a token that
+ * every proxy in the chain silently refuses to carry, surfacing later as a
+ * client that cannot connect for reasons nothing logs.
+ */
+export const MAX_ACCESS_TOKEN_LENGTH = 4096;
+
 export function issueAccessToken(
   payload: AccessTokenPayload,
   key: Buffer,
   nowMs: number = Date.now()
 ): string {
-  return sealAuthState(payload, key, nowMs, ACCESS_TOKEN_TTL_SECONDS);
+  const token = sealAuthState(payload, key, nowMs, ACCESS_TOKEN_TTL_SECONDS);
+
+  if (token.length > MAX_ACCESS_TOKEN_LENGTH) {
+    // Deliberately does not print the token or the payload: this is the most
+    // valuable envelope we issue and a length is enough to act on.
+    throw new Error(
+      `Refusing to issue an access token of ${token.length} characters ` +
+        `(limit ${MAX_ACCESS_TOKEN_LENGTH}). A token this size will be rejected by proxies ` +
+        'in the request path, so issuing it would produce a client that cannot connect and ' +
+        'no explanation. Something has been added to the sealed payload that is not bounded.'
+    );
+  }
+
+  return token;
 }
 
 /**

--- a/src/http/config.ts
+++ b/src/http/config.ts
@@ -201,6 +201,26 @@ export function authCodeKey(): Buffer {
   return deriveAuthCodeKey(INSFORGE_CONFIG.clientSecret);
 }
 
+/**
+ * And a fourth, for the access token we issue to MCP clients.
+ *
+ * Fourth purpose, fourth label, no relationship to the other three. This one
+ * seals the most valuable envelope we produce — it carries the platform access
+ * token — so it is the one that most needs its own key.
+ */
+const ACCESS_TOKEN_KEY_LABEL = 'mcp-access-token-v1';
+
+export function deriveAccessTokenKey(clientSecret: string): Buffer {
+  if (!clientSecret) {
+    throw new Error('INSFORGE_CLIENT_SECRET is required: the access token key is derived from it');
+  }
+  return createHmac('sha256', clientSecret).update(ACCESS_TOKEN_KEY_LABEL).digest();
+}
+
+export function accessTokenKey(): Buffer {
+  return deriveAccessTokenKey(INSFORGE_CONFIG.clientSecret);
+}
+
 // ============================================================================
 // Redis Configuration
 // ============================================================================

--- a/src/http/oauth-manager.ts
+++ b/src/http/oauth-manager.ts
@@ -205,18 +205,19 @@ export class OAuthManager {
     // Validate token and get user info
     const user = await validateToken(token);
 
-    // Get project access info
+    // Still called for its refusal, not for its return value: this is where we
+    // find out the signed-in user may actually reach the project they picked.
+    // Everything it returns beyond the id is re-fetched per request through the
+    // project-key cache, so none of it is sealed into the token — see
+    // access-token.ts for why a caller-influenced field in there is a denial of
+    // service against everyone who shares the project.
     const projectAccess = await getProjectAccess(token, projectId);
 
     const accessToken = issueAccessToken(
       {
         userId: user.id,
-        userEmail: user.email,
         platformAccessToken: token,
         projectId: projectAccess.projectId,
-        projectName: projectAccess.projectName,
-        organizationId: projectAccess.organizationId,
-        accessHost: projectAccess.accessHost,
       },
       accessTokenKey()
     );

--- a/src/http/oauth-manager.ts
+++ b/src/http/oauth-manager.ts
@@ -1,8 +1,9 @@
 import { createHash, randomBytes } from 'crypto';
-import { getRedisClient } from './redis.js';
 import { sealAuthState, openAuthState, InvalidAuthStateError } from './auth-state.js';
+import { issueAccessToken, readAccessToken } from './access-token.js';
+import { getProjectKeyCache } from './project-key-cache.js';
 import { newStateHandle } from './auth-state-cookie.js';
-import { authStateKey, authCodeKey } from './config.js';
+import { authStateKey, authCodeKey, accessTokenKey } from './config.js';
 import {
   validateToken,
   getProjectAccess,
@@ -39,7 +40,7 @@ export function generateState(): string {
 }
 
 /**
- * OAuth authorization state stored in Redis
+ * OAuth authorization state, sealed into a cookie rather than stored
  * Used during the OAuth flow before token exchange
  *
  * This stores both:
@@ -84,29 +85,9 @@ interface AuthorizationState {
   createdAt: number;
 }
 
-/**
- * Token binding stored in Redis
- * Links an OAuth token to a specific project
- */
-interface TokenBinding {
-  tokenHash: string;
-  userId: string;
-  userEmail: string;
-  projectId: string;
-  projectName: string;
-  organizationId: string;
-  accessHost: string;
-  apiKey: string;
-  createdAt: number;
-  lastUsedAt: number;
-}
-
-// Redis key prefixes
-const TOKEN_BINDING_PREFIX = 'mcp:auth:binding:';
 
 // TTLs
 const AUTH_CODE_TTL = 5 * 60; // 5 minutes
-const TOKEN_BINDING_TTL = 30 * 24 * 60 * 60; // 30 days
 
 /**
  * Generate a hash of the token for storage
@@ -215,8 +196,6 @@ export class OAuthManager {
     token: string,
     projectId: string
   ): Promise<string> {
-    const redis = getRedisClient();
-
     // Validate the state exists
     const authState = await this.getAuthorizationState(stateId, handle);
     if (!authState) {
@@ -229,27 +208,22 @@ export class OAuthManager {
     // Get project access info
     const projectAccess = await getProjectAccess(token, projectId);
 
-    // Create token binding
-    const tokenHash = hashToken(token);
-    const binding: TokenBinding = {
-      tokenHash,
-      userId: user.id,
-      userEmail: user.email,
-      projectId: projectAccess.projectId,
-      projectName: projectAccess.projectName,
-      organizationId: projectAccess.organizationId,
-      accessHost: projectAccess.accessHost,
-      apiKey: projectAccess.apiKey,
-      createdAt: Date.now(),
-      lastUsedAt: Date.now(),
-    };
-
-    // Store the binding
-    await redis.setex(
-      TOKEN_BINDING_PREFIX + tokenHash,
-      TOKEN_BINDING_TTL,
-      JSON.stringify(binding)
+    const accessToken = issueAccessToken(
+      {
+        userId: user.id,
+        userEmail: user.email,
+        platformAccessToken: token,
+        projectId: projectAccess.projectId,
+        projectName: projectAccess.projectName,
+        organizationId: projectAccess.organizationId,
+        accessHost: projectAccess.accessHost,
+      },
+      accessTokenKey()
     );
+
+    // No binding row: the access token IS the record. See access-token.ts for
+    // why the platform token goes in and the project API key deliberately does
+    // not.
 
     // PKCE is REQUIRED for a sealed code, and this is the one place the
     // stateless rewrite genuinely tightens behaviour rather than preserving it.
@@ -276,7 +250,7 @@ export class OAuthManager {
     // §4.1.2 wants a code short-lived, and a replayable one wants it more.
     const code = sealAuthState(
       {
-        tokenHash,
+        accessToken,
         redirectUri: authState.redirectUri,
         codeChallenge: authState.codeChallenge,
         codeChallengeMethod: authState.codeChallengeMethod,
@@ -308,11 +282,11 @@ export class OAuthManager {
     code: string,
     redirectUri: string,
     codeVerifier?: string
-  ): Promise<{ tokenHash: string }> {
+  ): Promise<{ accessToken: string }> {
     // No GETDEL, because there is nothing stored. Replay is bounded by PKCE
     // (required at issue time) and by the five-minute expiry sealed inside.
     let payload: {
-      tokenHash: string;
+      accessToken: string;
       redirectUri: string;
       codeChallenge?: string;
       codeChallengeMethod?: string;
@@ -323,7 +297,7 @@ export class OAuthManager {
       throw new Error('Invalid or expired authorization code');
     }
 
-    const { tokenHash, redirectUri: storedRedirectUri, codeChallenge, codeChallengeMethod } = payload;
+    const { accessToken, redirectUri: storedRedirectUri, codeChallenge, codeChallengeMethod } = payload;
 
     // Validate redirect URI
     if (redirectUri !== storedRedirectUri) {
@@ -356,68 +330,16 @@ export class OAuthManager {
       }
     }
 
-    return { tokenHash };
+    return { accessToken };
   }
-
   /**
-   * Get token binding by token hash
-   */
-  async getTokenBinding(tokenHash: string): Promise<TokenBinding | null> {
-    const redis = getRedisClient();
-    const data = await redis.get(TOKEN_BINDING_PREFIX + tokenHash);
-
-    if (!data) {
-      return null;
-    }
-
-    return JSON.parse(data) as TokenBinding;
-  }
-
-  /**
-   * Get token binding by raw token
-   */
-  async getBindingByToken(token: string): Promise<TokenBinding | null> {
-    const tokenHash = hashToken(token);
-    return this.getTokenBinding(tokenHash);
-  }
-
-  /**
-   * Update last used time for a token binding
-   */
-  async touchBinding(tokenHash: string): Promise<void> {
-    const redis = getRedisClient();
-    const binding = await this.getTokenBinding(tokenHash);
-
-    if (binding) {
-      binding.lastUsedAt = Date.now();
-      await redis.setex(
-        TOKEN_BINDING_PREFIX + tokenHash,
-        TOKEN_BINDING_TTL,
-        JSON.stringify(binding)
-      );
-    }
-  }
-
-  /**
-   * Revoke a token binding
-   */
-  async revokeBinding(tokenHash: string): Promise<void> {
-    const redis = getRedisClient();
-    await redis.del(TOKEN_BINDING_PREFIX + tokenHash);
-  }
-
-  /**
-   * Resolve project info from OAuth token or tokenHash
-   * This is the main entry point used by the MCP server
+   * Everything a tool call needs, from the token alone plus one cached lookup.
    *
-   * The token parameter can be either:
-   * 1. A tokenHash (returned by /oauth/token endpoint) - used by MCP clients after OAuth
-   * 2. A raw Insforge OAuth token - used for direct API access
-   *
-   * Flow:
-   * 1. Try to find binding using token directly as tokenHash
-   * 2. If not found, try hashing the token and look up again
-   * 3. If still not found, return null (client needs to go through OAuth flow)
+   * The token used to BE the Redis key; now it carries its own record. What it
+   * deliberately does not carry is the project API key — that is fetched here,
+   * from a 60-second cache, so the platform stays the authority on revocation.
+   * See project-key-cache.ts for why that TTL is fixed rather than bounded by
+   * the token's own expiry.
    */
   async resolveProjectFromToken(token: string): Promise<{
     apiKey: string;
@@ -428,33 +350,51 @@ export class OAuthManager {
     organizationId: string;
     oauthTokenHash: string;
   } | null> {
-    // First, try using the token directly as a tokenHash
-    // This handles the case where MCP clients send the tokenHash from /oauth/token
-    let binding = await this.getTokenBinding(token);
-    let actualTokenHash = token;
-
-    if (!binding) {
-      // Try hashing the token (in case it's a raw Insforge token)
-      actualTokenHash = hashToken(token);
-      binding = await this.getTokenBinding(actualTokenHash);
-    }
-
-    if (!binding) {
-      // No binding found - client needs to complete OAuth flow
+    const payload = readAccessToken(token, accessTokenKey());
+    if (!payload) {
+      // Not ours, tampered, or expired — all the same 401 to a caller, and
+      // deliberately indistinguishable so nothing downstream can branch on it.
       return null;
     }
 
-    // Update last used time
-    await this.touchBinding(actualTokenHash);
+    const cache = getProjectKeyCache();
+    let key = cache.get(payload.userId, payload.projectId);
+
+    if (!key) {
+      // Asked afresh, which is what makes a revoked grant stop working within
+      // the cache TTL rather than at the end of the token's life.
+      try {
+        const access = await getProjectAccess(payload.platformAccessToken, payload.projectId);
+        key = {
+          apiKey: access.apiKey,
+          accessHost: access.accessHost,
+          projectName: access.projectName,
+          organizationId: access.organizationId,
+        };
+        cache.set(payload.userId, payload.projectId, key);
+      } catch (error) {
+        // A refusal here is the platform saying this user may no longer reach
+        // this project. That is a 401 for the caller, not a 500 — the request
+        // is well-formed and our server is fine.
+        console.log(
+          `[OAuth] Project access refused for ${payload.userId}: ${
+            error instanceof Error ? error.message : 'unknown'
+          }`
+        );
+        return null;
+      }
+    }
 
     return {
-      apiKey: binding.apiKey,
-      apiBaseUrl: binding.accessHost,
-      projectId: binding.projectId,
-      projectName: binding.projectName,
-      userId: binding.userId,
-      organizationId: binding.organizationId,
-      oauthTokenHash: actualTokenHash,
+      apiKey: key.apiKey,
+      apiBaseUrl: key.accessHost,
+      projectId: payload.projectId,
+      projectName: key.projectName,
+      userId: payload.userId,
+      organizationId: key.organizationId,
+      // A hash of the bearer, never the bearer itself — the analytics and
+      // session fields want an opaque handle and nothing more.
+      oauthTokenHash: hashToken(token),
     };
   }
 
@@ -466,45 +406,6 @@ export class OAuthManager {
     projects: Project[];
   }>> {
     return getAllUserProjects(token);
-  }
-
-  /**
-   * Bind a token to a project directly (skip OAuth code flow)
-   * Used when user selects a project via API
-   */
-  async bindTokenToProject(token: string, projectId: string): Promise<TokenBinding> {
-    const redis = getRedisClient();
-
-    // Validate token and get user info
-    const user = await validateToken(token);
-
-    // Get project access info
-    const projectAccess = await getProjectAccess(token, projectId);
-
-    // Create token binding
-    const tokenHash = hashToken(token);
-    const binding: TokenBinding = {
-      tokenHash,
-      userId: user.id,
-      userEmail: user.email,
-      projectId: projectAccess.projectId,
-      projectName: projectAccess.projectName,
-      organizationId: projectAccess.organizationId,
-      accessHost: projectAccess.accessHost,
-      apiKey: projectAccess.apiKey,
-      createdAt: Date.now(),
-      lastUsedAt: Date.now(),
-    };
-
-    // Store the binding
-    await redis.setex(
-      TOKEN_BINDING_PREFIX + tokenHash,
-      TOKEN_BINDING_TTL,
-      JSON.stringify(binding)
-    );
-
-    console.log(`[OAuthManager] Token bound to project: ${projectAccess.projectName}`);
-    return binding;
   }
 }
 

--- a/src/http/project-key-cache.test.ts
+++ b/src/http/project-key-cache.test.ts
@@ -50,13 +50,85 @@ describe('the project key cache', () => {
     expect(c.get('user_b', 'proj_1', T0)).toEqual(value);
   });
 
-  it('does not leak entries once they expire', () => {
-    // The binding leaked because nothing ever removed it. This one drops the
-    // entry on the read that finds it stale.
+  it('drops an entry on the read that finds it stale', () => {
     const c = new ProjectKeyCache();
     c.set('user_a', 'proj_1', value, T0);
     expect(c.size()).toBe(1);
     c.get('user_a', 'proj_1', T0 + PROJECT_KEY_TTL_MS);
     expect(c.size()).toBe(0);
+  });
+
+  it('evicts entries NOBODY reads again — the leak Quinn measured', () => {
+    // The original checked expiry on read only, and its comment claimed an
+    // unread entry cost a slot "for 60 seconds". Measured, it cost one
+    // forever: 10,000 written, one more an hour later, nothing re-read, size
+    // 10,001 — each holding a project API key well past the TTL that exists to
+    // bound exactly that.
+    const c = new ProjectKeyCache();
+    for (let i = 0; i < 10_000; i++) c.set(`user_${i}`, 'proj', value, T0);
+    expect(c.size()).toBe(10_000);
+
+    c.set('someone', 'else', value, T0 + 60 * PROJECT_KEY_TTL_MS);
+    expect(c.size()).toBe(1);
+  });
+
+  it('scans at most once a second, and the read path covers the gap', () => {
+    // Eviction is O(n) on a per-request path, so it is rate-limited rather than
+    // run on every write. This pins the amortisation — and, more importantly,
+    // that a still-resident expired entry is NEVER SERVED: correctness lives on
+    // the read path, tidiness on the write path.
+    const c = new ProjectKeyCache();
+    c.set('user_a', 'proj_1', value, T0); // scans; a expires at T0 + TTL
+    c.set('user_b', 'proj_1', value, T0 + PROJECT_KEY_TTL_MS - 500); // scans; a still fresh
+
+    // 501ms after that scan: inside the interval, so no scan runs and user_a's
+    // expired entry is still resident.
+    c.set('user_c', 'proj_1', value, T0 + PROJECT_KEY_TTL_MS + 1);
+    expect(c.size()).toBe(3);
+
+    // ...but it cannot be read.
+    expect(c.get('user_a', 'proj_1', T0 + PROJECT_KEY_TTL_MS + 1)).toBeUndefined();
+  });
+
+  it('cannot confuse two (user, project) pairs that join to the same string', () => {
+    // `${userId} ${projectId}` made these one entry:
+    //   ('a', 'b c')  and  ('a b', 'c')  both -> "a b c"
+    // Unreachable while both are platform UUIDs, and a live cross-tenant bug
+    // the moment project_id becomes a caller-supplied tool argument. Nesting
+    // the maps makes it unrepresentable rather than merely unlikely.
+    const first = { ...value, apiKey: 'ik_first' };
+    const second = { ...value, apiKey: 'ik_second' };
+    const c = new ProjectKeyCache();
+
+    c.set('a', 'b c', first, T0);
+    c.set('a b', 'c', second, T0);
+
+    expect(c.get('a', 'b c', T0)).toEqual(first);
+    expect(c.get('a b', 'c', T0)).toEqual(second);
+    expect(c.size()).toBe(2);
+  });
+
+  it('forgets a user without forgetting one whose id is a prefix of theirs', () => {
+    // forgetUser was a prefix scan over joined keys, carrying the same
+    // assumption. A structural key makes the question not arise.
+    const c = new ProjectKeyCache();
+    c.set('user', 'proj_1', value, T0);
+    c.set('user_extended', 'proj_1', value, T0);
+
+    c.forgetUser('user');
+
+    expect(c.get('user', 'proj_1', T0)).toBeUndefined();
+    expect(c.get('user_extended', 'proj_1', T0)).toEqual(value);
+  });
+
+  it('leaves no empty shell behind for a user whose entries are all gone', () => {
+    // The nesting adds a container per user; if those were never removed the
+    // leak would simply move up a level.
+    const c = new ProjectKeyCache();
+    c.set('user_a', 'proj_1', value, T0);
+    c.get('user_a', 'proj_1', T0 + PROJECT_KEY_TTL_MS);
+    expect(c.size()).toBe(0);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((c as any).byUser.size).toBe(0);
   });
 });

--- a/src/http/project-key-cache.test.ts
+++ b/src/http/project-key-cache.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest';
+import { ProjectKeyCache, PROJECT_KEY_TTL_MS } from './project-key-cache.js';
+
+const value = {
+  apiKey: 'ik_secret',
+  accessHost: 'https://p.insforge.app',
+  projectName: 'demo',
+  organizationId: 'org_1',
+};
+const T0 = 1_700_000_000_000;
+
+describe('the project key cache', () => {
+  it('returns what was put in, within the TTL', () => {
+    const c = new ProjectKeyCache();
+    c.set('user_a', 'proj_1', value, T0);
+    expect(c.get('user_a', 'proj_1', T0)).toEqual(value);
+    expect(c.get('user_a', 'proj_1', T0 + PROJECT_KEY_TTL_MS - 1)).toEqual(value);
+  });
+
+  it('expires exactly at the TTL, so revocation cannot be stale for longer', () => {
+    // The number that keeps the platform's revoke meaningful. Caching bounded
+    // by the token's own exp — which is what I first specced — would make
+    // revoke a no-op from our side for the life of the token.
+    const c = new ProjectKeyCache();
+    c.set('user_a', 'proj_1', value, T0);
+    expect(c.get('user_a', 'proj_1', T0 + PROJECT_KEY_TTL_MS)).toBeUndefined();
+    expect(PROJECT_KEY_TTL_MS).toBe(60_000);
+  });
+
+  it('never serves one user the key another user got for the same project', () => {
+    // Two users can both reach a project with different grants. A cache keyed
+    // on the project alone would be a cross-tenant bug.
+    const c = new ProjectKeyCache();
+    c.set('user_a', 'proj_1', value, T0);
+    expect(c.get('user_b', 'proj_1', T0)).toBeUndefined();
+  });
+
+  it('keeps projects apart for one user', () => {
+    const c = new ProjectKeyCache();
+    c.set('user_a', 'proj_1', value, T0);
+    expect(c.get('user_a', 'proj_2', T0)).toBeUndefined();
+  });
+
+  it('forgets one user without touching another', () => {
+    const c = new ProjectKeyCache();
+    c.set('user_a', 'proj_1', value, T0);
+    c.set('user_b', 'proj_1', value, T0);
+    c.forgetUser('user_a');
+    expect(c.get('user_a', 'proj_1', T0)).toBeUndefined();
+    expect(c.get('user_b', 'proj_1', T0)).toEqual(value);
+  });
+
+  it('does not leak entries once they expire', () => {
+    // The binding leaked because nothing ever removed it. This one drops the
+    // entry on the read that finds it stale.
+    const c = new ProjectKeyCache();
+    c.set('user_a', 'proj_1', value, T0);
+    expect(c.size()).toBe(1);
+    c.get('user_a', 'proj_1', T0 + PROJECT_KEY_TTL_MS);
+    expect(c.size()).toBe(0);
+  });
+});

--- a/src/http/project-key-cache.ts
+++ b/src/http/project-key-cache.ts
@@ -22,6 +22,33 @@
 
 export const PROJECT_KEY_TTL_MS = 60 * 1000;
 
+/**
+ * How often the write path is allowed to scan for expired entries.
+ *
+ * The first version checked expiry on read only, and its comment claimed an
+ * unread entry "costs one Map slot for 60 seconds". Quinn measured it: it costs
+ * one Map slot FOREVER.
+ *
+ *   10,000 entries written, one more an hour later, nothing re-read -> 10,001
+ *
+ * Every one of those slots holds a project API key, in memory, long past the
+ * TTL that exists to bound exactly that — for the life of the container and
+ * across every user who ever signed in. `forgetUser` only fires on sign-out,
+ * which is the case that already ends well.
+ *
+ * So eviction moves to the write path. Rate-limited rather than run on every
+ * `set`, because the scan is O(n) and the write path is per-request: at one
+ * scan per second the cost is bounded whatever the request rate, and an expired
+ * entry outlives its expiry by at most a second.
+ *
+ * Deliberately NOT a timer. A background sweeper for a 60-second cache is more
+ * machinery than the thing it manages, and it would keep a container awake to
+ * tidy a Map. The honest residual: if writes stop entirely, the last window's
+ * entries stay until the next write — bounded by one TTL window rather than
+ * unbounded, which was the defect.
+ */
+const EVICTION_SCAN_INTERVAL_MS = 1000;
+
 export interface ProjectKey {
   apiKey: string;
   accessHost: string;
@@ -35,56 +62,100 @@ interface Entry {
 }
 
 /**
- * Keyed by user AND project.
+ * Keyed by user AND project, as a map of maps rather than a joined string.
  *
  * Not by project alone: two users can both reach one project with different
  * grants, and a cache keyed on the project would serve one user's key to the
  * other. That is the shape of a cross-tenant bug, so the key is the pair.
+ *
+ * THE NESTING IS THE FIX, and it replaces a `${userId} ${projectId}` join that
+ * Quinn broke in two lines:
+ *
+ *   set('a',   'b c', FIRST)      both produce the key "a b c"
+ *   set('a b', 'c',   SECOND)
+ *   get('a',   'b c')  ->  SECOND — one entry, another user's key
+ *
+ * Not reachable today: both values are platform UUIDs. But `project_id` is
+ * about to become a tool argument, and then a caller who can put a space in it
+ * is aiming at a chosen cache slot. The paragraph above says the pair IS the
+ * key precisely to prevent cross-tenant serving, so an encoding under which two
+ * pairs collide contradicts the thing it was written for.
+ *
+ * A delimiter would close this instance. Nesting closes the CLASS: two maps
+ * cannot collide whatever the strings contain, there is no separator for a
+ * caller to smuggle, and nobody has to keep obeying a rule about which
+ * character is reserved. It also makes forgetUser a single delete instead of a
+ * prefix scan over every entry — and that prefix scan was the same
+ * joined-string assumption, one method further down.
  */
-function cacheKey(userId: string, projectId: string): string {
-  return `${userId} ${projectId}`;
-}
-
 export class ProjectKeyCache {
-  private entries = new Map<string, Entry>();
+  private byUser = new Map<string, Map<string, Entry>>();
+  private lastScanAt = 0;
 
   /**
-   * The cached key, or undefined. Expiry is checked on read rather than swept:
-   * an entry nobody asks for again costs one Map slot for 60 seconds, and a
-   * sweeper for that would be more machinery than the thing it manages.
+   * The cached key, or undefined. Expiry is still checked here: a read must
+   * never serve a stale key, whether or not a write has swept it yet.
    */
   get(userId: string, projectId: string, now: number = Date.now()): ProjectKey | undefined {
-    const key = cacheKey(userId, projectId);
-    const entry = this.entries.get(key);
+    const forUser = this.byUser.get(userId);
+    if (!forUser) return undefined;
+
+    const entry = forUser.get(projectId);
     if (!entry) return undefined;
+
     if (now >= entry.expiresAt) {
-      this.entries.delete(key);
+      forUser.delete(projectId);
+      if (forUser.size === 0) this.byUser.delete(userId);
       return undefined;
     }
     return entry.value;
   }
 
   set(userId: string, projectId: string, value: ProjectKey, now: number = Date.now()): void {
-    this.entries.set(cacheKey(userId, projectId), { value, expiresAt: now + PROJECT_KEY_TTL_MS });
+    let forUser = this.byUser.get(userId);
+    if (!forUser) {
+      forUser = new Map();
+      this.byUser.set(userId, forUser);
+    }
+    forUser.set(projectId, { value, expiresAt: now + PROJECT_KEY_TTL_MS });
+
+    this.evictExpired(now);
   }
 
   /**
    * Drop everything for one user.
    *
    * The one case where a stale entry is actively wrong rather than merely old:
-   * a sign-out. Cheap, and it means a revoked session cannot keep using a key
-   * we already handed ourselves.
+   * a sign-out. Now a single delete rather than a scan over every entry in the
+   * cache, because the user is a level of the structure rather than a prefix of
+   * a string.
    */
   forgetUser(userId: string): void {
-    const prefix = `${userId} `;
-    for (const key of this.entries.keys()) {
-      if (key.startsWith(prefix)) this.entries.delete(key);
-    }
+    this.byUser.delete(userId);
   }
 
   /** For /health, so the cache is observable rather than a black box. */
   size(): number {
-    return this.entries.size;
+    let total = 0;
+    for (const forUser of this.byUser.values()) total += forUser.size;
+    return total;
+  }
+
+  /**
+   * Drop everything expired. Rate-limited — see EVICTION_SCAN_INTERVAL_MS for
+   * why this runs on the write path at most once a second rather than on every
+   * write or on a timer.
+   */
+  private evictExpired(now: number): void {
+    if (now - this.lastScanAt < EVICTION_SCAN_INTERVAL_MS) return;
+    this.lastScanAt = now;
+
+    for (const [userId, forUser] of this.byUser) {
+      for (const [projectId, entry] of forUser) {
+        if (now >= entry.expiresAt) forUser.delete(projectId);
+      }
+      if (forUser.size === 0) this.byUser.delete(userId);
+    }
   }
 }
 

--- a/src/http/project-key-cache.ts
+++ b/src/http/project-key-cache.ts
@@ -1,0 +1,96 @@
+/**
+ * The project API key, fetched per request and cached briefly.
+ *
+ * It used to live in the token binding, written once at sign-in and reused for
+ * thirty days. That is what made the binding necessary, and it had two
+ * consequences nobody chose: a rotated project key kept working until the
+ * binding expired, and the MCP could not survive a restart.
+ *
+ * So fetch it instead. The cost is a platform round-trip, and Iris measured the
+ * floor: ~60ms of platform server time, location-independent, on a route that
+ * does nothing. On tools that otherwise take 20ms that is the dominant cost —
+ * which is why this cache is part of the change rather than an optimisation.
+ *
+ * THE TTL IS FIXED AND SHORT, AND THAT IS THE WHOLE DESIGN. With the binding
+ * gone there is no row to delete, so revocation belongs to the platform:
+ * `validateAccessToken` checks `revoked` on every call. Caching bounded by the
+ * token's own `exp` — which is what I first specced — would have made the
+ * platform's revoke endpoint a no-op from our side for the life of the token.
+ * Sixty seconds is the bound on how stale a revocation can be, and it is the
+ * number that keeps "revoke" meaning something.
+ */
+
+export const PROJECT_KEY_TTL_MS = 60 * 1000;
+
+export interface ProjectKey {
+  apiKey: string;
+  accessHost: string;
+  projectName: string;
+  organizationId: string;
+}
+
+interface Entry {
+  value: ProjectKey;
+  expiresAt: number;
+}
+
+/**
+ * Keyed by user AND project.
+ *
+ * Not by project alone: two users can both reach one project with different
+ * grants, and a cache keyed on the project would serve one user's key to the
+ * other. That is the shape of a cross-tenant bug, so the key is the pair.
+ */
+function cacheKey(userId: string, projectId: string): string {
+  return `${userId} ${projectId}`;
+}
+
+export class ProjectKeyCache {
+  private entries = new Map<string, Entry>();
+
+  /**
+   * The cached key, or undefined. Expiry is checked on read rather than swept:
+   * an entry nobody asks for again costs one Map slot for 60 seconds, and a
+   * sweeper for that would be more machinery than the thing it manages.
+   */
+  get(userId: string, projectId: string, now: number = Date.now()): ProjectKey | undefined {
+    const key = cacheKey(userId, projectId);
+    const entry = this.entries.get(key);
+    if (!entry) return undefined;
+    if (now >= entry.expiresAt) {
+      this.entries.delete(key);
+      return undefined;
+    }
+    return entry.value;
+  }
+
+  set(userId: string, projectId: string, value: ProjectKey, now: number = Date.now()): void {
+    this.entries.set(cacheKey(userId, projectId), { value, expiresAt: now + PROJECT_KEY_TTL_MS });
+  }
+
+  /**
+   * Drop everything for one user.
+   *
+   * The one case where a stale entry is actively wrong rather than merely old:
+   * a sign-out. Cheap, and it means a revoked session cannot keep using a key
+   * we already handed ourselves.
+   */
+  forgetUser(userId: string): void {
+    const prefix = `${userId} `;
+    for (const key of this.entries.keys()) {
+      if (key.startsWith(prefix)) this.entries.delete(key);
+    }
+  }
+
+  /** For /health, so the cache is observable rather than a black box. */
+  size(): number {
+    return this.entries.size;
+  }
+}
+
+let cache: ProjectKeyCache | null = null;
+
+export function getProjectKeyCache(): ProjectKeyCache {
+  if (!cache) cache = new ProjectKeyCache();
+  return cache;
+}

--- a/src/http/server.ts
+++ b/src/http/server.ts
@@ -45,6 +45,9 @@ import {
   isAcceptableClientState,
   MAX_CLIENT_STATE_LENGTH,
 } from './auth-state-cookie.js';
+import { ACCESS_TOKEN_TTL_SECONDS, readAccessToken } from './access-token.js';
+import { getProjectKeyCache } from './project-key-cache.js';
+import { accessTokenKey } from './config.js';
 import { statusForHttpError } from './error-status.js';
 import { PACKAGE_VERSION } from '../shared/version.js';
 
@@ -738,7 +741,7 @@ app.post(OAUTH_ENDPOINTS.token, async (req: Request, res: Response) => {
 
     try {
       const oauthManager = getOAuthManager();
-      const { tokenHash } = await oauthManager.exchangeCode(
+      const { accessToken } = await oauthManager.exchangeCode(
         code as string,
         redirect_uri as string,
         code_verifier as string | undefined
@@ -750,9 +753,13 @@ app.post(OAUTH_ENDPOINTS.token, async (req: Request, res: Response) => {
       });
 
       res.json({
-        access_token: tokenHash,
+        access_token: accessToken,
         token_type: 'Bearer',
-        expires_in: 30 * 24 * 60 * 60,
+        // 24 hours, not the binding's 30 days. A value that cannot be revoked
+        // directly should not live for a month, and the platform token sealed
+        // inside has its own expiry — whichever runs out first ends the
+        // session, which is the safe direction.
+        expires_in: ACCESS_TOKEN_TTL_SECONDS,
         scope: 'mcp:read mcp:write',
       });
     } catch (error) {
@@ -803,13 +810,25 @@ app.post(OAUTH_ENDPOINTS.revoke, async (req: Request, res: Response) => {
     });
   }
 
+  // There is no row to delete any more: the token carries its own record. What
+  // we CAN do is drop the cached project key, so the very next call re-asks the
+  // platform instead of using a key we already fetched — and the platform is
+  // where revocation is actually enforced (validateAccessToken checks
+  // `revoked` on every call).
+  //
+  // RFC 7009 §2.2 wants 200 whatever happens, including for a token we do not
+  // recognise, so that this endpoint cannot be used to probe which tokens are
+  // real. That was already the behaviour and it stays.
   try {
-    const oauthManager = getOAuthManager();
-    await oauthManager.revokeBinding(token as string);
-    res.status(200).send();
+    const payload = readAccessToken(token as string, accessTokenKey());
+    if (payload) {
+      getProjectKeyCache().forgetUser(payload.userId);
+      console.log(`[OAuth] Cached project keys dropped for ${payload.userId} on revoke`);
+    }
   } catch {
-    res.status(200).send();
+    // Deliberately swallowed: see above.
   }
+  res.status(200).send();
 });
 
 // ============================================================================
@@ -852,18 +871,38 @@ app.post(API_ENDPOINTS.bindProject, async (req: Request, res: Response) => {
   const token = authHeader.substring(7);
   const projectId = req.params.projectId as string;
 
+  // A token can no longer be re-pointed at another project, because there is no
+  // row to update — the project is sealed inside the token the client already
+  // holds. Saying so is better than the alternatives: silently doing nothing
+  // would look like success, and issuing a NEW token here would hand a caller a
+  // credential through an endpoint that never authenticated anyone.
   try {
-    const oauthManager = getOAuthManager();
-    const binding = await oauthManager.bindTokenToProject(token, projectId);
+    const payload = readAccessToken(token, accessTokenKey());
+    if (!payload) {
+      return res.status(401).json({ error: 'Invalid or expired token' });
+    }
 
-    res.json({
-      success: true,
-      project: {
-        id: binding.projectId,
-        name: binding.projectName,
-        organizationId: binding.organizationId,
-      },
-      message: 'Token successfully bound to project. You can now use this token with the MCP endpoint.',
+    if (payload.projectId === projectId) {
+      // Already there. Idempotent rather than an error: a client retrying is
+      // not making a mistake.
+      return res.json({
+        success: true,
+        project: {
+          id: payload.projectId,
+          name: payload.projectName,
+          organizationId: payload.organizationId,
+        },
+        message: 'This token is already scoped to that project.',
+      });
+    }
+
+    return res.status(409).json({
+      error: 'Token is scoped to a different project',
+      details:
+        `This token is scoped to ${payload.projectId} and cannot be re-pointed: the project ` +
+        'is part of the token rather than a server-side record. Authorize again to get a token ' +
+        'for another project.',
+      currentProjectId: payload.projectId,
     });
   } catch (error) {
     console.error('Bind project error:', error);
@@ -931,8 +970,8 @@ app.post(STREAMABLE_HTTP_ENDPOINTS.mcp, async (req: Request, res: Response) => {
 
       if (oauthToken && !legacyApiBaseUrl) {
         return sendUnauthorized(res, {
-          error: 'project_binding_required',
-          error_description: 'OAuth token is valid but not bound to a project. Complete the OAuth flow or call POST /api/projects/{projectId}/bind',
+          error: 'authorization_required',
+          error_description: 'Your sign-in is no longer valid for this project — the platform refused it, or it expired. Authorize again. Complete the OAuth flow or call POST /api/projects/{projectId}/bind',
           oauth_authorize_url: `${SERVER_CONFIG.publicUrl}${OAUTH_ENDPOINTS.authorize}`,
           projects_url: `${SERVER_CONFIG.publicUrl}${API_ENDPOINTS.projects}`,
         }, STREAMABLE_HTTP_ENDPOINTS.mcp);
@@ -1117,8 +1156,8 @@ app.get(SSE_ENDPOINTS.sse, async (req: Request, res: Response) => {
 
     if (oauthToken && !legacyApiBaseUrl) {
       return sendUnauthorized(res, {
-        error: 'project_binding_required',
-        error_description: 'OAuth token is valid but not bound to a project. Complete the OAuth flow.',
+        error: 'authorization_required',
+        error_description: 'Your sign-in is no longer valid for this project — the platform refused it, or it expired. Authorize again. Complete the OAuth flow.',
       }, SSE_ENDPOINTS.sse);
     }
 
@@ -1296,8 +1335,9 @@ async function startServer() {
       // below says so instead of promising a login that will not complete.
       console.warn(
         '[Redis] Not configured (no REDIS_URL or REDIS_HOST). ' +
-          'Serving /health, discovery and the 401 challenge; /oauth/* and every ' +
-          'session path will fail until the remaining Redis uses are removed.'
+          'The whole OAuth path now runs without it — registration, sign-in, ' +
+          'tokens. Only MCP SESSIONS still need Redis; /mcp and /sse will fail ' +
+          'until those move in-process.'
       );
     }
 
@@ -1308,7 +1348,7 @@ async function startServer() {
       // configured and never reached ioredis. Print what is true.
       const redisLine = isRedisConfigured()
         ? `${redisConfig.host}:${redisConfig.port} (TLS: ${redisConfig.tls}, Cluster: ${redisConfig.cluster})`
-        : 'not configured — /oauth/* and sessions unavailable';
+        : 'not configured — OAuth works; MCP sessions unavailable';
       console.log(`
 ╔═══════════════════════════════════════════════════════════════════════╗
 ║              Insforge MCP Remote Server (OAuth)                       ║

--- a/src/http/server.ts
+++ b/src/http/server.ts
@@ -894,9 +894,24 @@ app.get(API_ENDPOINTS.projects, async (req: Request, res: Response) => {
 
   const token = authHeader.substring(7);
 
+  // UNSEAL FIRST. This handed our own bearer straight to the platform, which
+  // worked only while the bearer WAS a platform token. Since the token became a
+  // sealed envelope, the platform receives a string it has never issued and
+  // answers 401 — so `/api/projects` has been broken for every caller, and with
+  // it `list-projects`, the capability this whole design exists to enable.
+  //
+  // The bug is the shape the sealed token invites: every place that used to
+  // forward the bearer now has to open it and forward what is INSIDE. This was
+  // the last one, and it was missed because nothing calls this endpoint in
+  // tests — the project-selection page is its only real caller.
+  const payload = readAccessToken(token, accessTokenKey());
+  if (!payload) {
+    return res.status(401).json({ error: 'Invalid or expired token' });
+  }
+
   try {
     const oauthManager = getOAuthManager();
-    const projects = await oauthManager.getAvailableProjects(token);
+    const projects = await oauthManager.getAvailableProjects(payload.platformAccessToken);
     res.json({ organizations: projects });
   } catch (error) {
     console.error('Get projects error:', error);

--- a/src/http/server.ts
+++ b/src/http/server.ts
@@ -885,13 +885,19 @@ app.post(API_ENDPOINTS.bindProject, async (req: Request, res: Response) => {
     if (payload.projectId === projectId) {
       // Already there. Idempotent rather than an error: a client retrying is
       // not making a mistake.
+      //
+      // The id and nothing else. This used to echo the project's name and
+      // organization out of the token, and those two fields are exactly what
+      // made the sealed payload unbounded — a project name has no maximum
+      // length upstream. They are display data, so they left the credential
+      // (access-token.ts) rather than staying in it to serve one response body.
+      //
+      // Re-fetching them here to keep the shape was the tempting move and the
+      // wrong one: it would put a platform round-trip, and a platform outage,
+      // in the path of an endpoint that answers purely from the token today.
       return res.json({
         success: true,
-        project: {
-          id: payload.projectId,
-          name: payload.projectName,
-          organizationId: payload.organizationId,
-        },
+        project: { id: payload.projectId },
         message: 'This token is already scoped to that project.',
       });
     }


### PR DESCRIPTION
**This is the cutover.** `mcp:auth:binding:` — the last Redis use in the OAuth path — is deleted here, not prepared for. The prefix, the `setex`/`get`/`del` calls and the `getRedisClient` import all leave `oauth-manager.ts`, and `server.ts` is rewired to the new token in the same commit. After this, OAuth runs with Redis unconfigured; only MCP **sessions** still need it.

An earlier draft of this description said "two modules, no wiring yet". That was true of the first commit and stopped being true; read the file list, not that sentence.

## What changes, in order of blast radius

**1. The bearer stops being a Redis key.** `resolveProjectFromToken` no longer looks anything up: it opens the token. `/oauth/token` returns the sealed value instead of a token hash, and `expires_in` goes from 30 days to 24h. Every token issued before this deploy stops resolving — the binding rows they point at are no longer read. Clients re-authorize; there is no migration path and none is worth building for a value with a 30-day tail and a working `/authorize`.

**2. A stolen token now reaches every project the user can, not one.** The sealed envelope carries the **platform access token**, because `list-projects` / `create-project` / `switch-project` need platform authority and today we discard that token after the picker uses it once. Tony chose this explicitly ("they can have more permission", 07-29 10:07) and Max has it on the record. It is the largest security change in the rewrite and it lands with this merge — a reviewer should see it as chosen, not inherited.

**3. Revocation moves to the platform.** There is no row to delete, so `/oauth/revoke` drops the cached project key and returns 200 (RFC 7009 §2.2), and enforcement is the platform's `validateAccessToken` `revoked` check on every call. The project-key cache TTL is therefore the bound on how stale a revocation can be — 60s, fixed. That is the design, not a tuning knob: caching bounded by `exp`, which I first specced, would have made revoke a no-op from our side.

**4. `POST /api/projects/{id}/bind` can no longer re-point a token.** The project is sealed inside the token the client already holds. 200 with `{id}` only if it is already scoped there, 409 otherwise. Silently succeeding would lie; issuing a new token from an endpoint that never authenticated anyone would be worse.

**5. `/api/projects` unseals the bearer before calling the platform** — the one real bug fixed here. It forwarded our bearer straight through, which worked only while the bearer *was* a platform token; since the seal it got a 401, taking `list-projects` with it. Every place that forwarded the bearer now has to forward what is *inside* it. This was the last one, and nothing in the suite calls this endpoint.

**6. The `project_binding_required` 401 becomes `authorization_required`** on `/mcp` and `/sse`, with reauth guidance. Clients matching on the old string see a new one.

## The two new modules

`access-token.ts` — AES-256-GCM, fourth derived key, fourth label. Encrypted rather than signed for a stronger reason than the auth state: a signed-but-readable bearer would publish a platform credential to anyone who saw the header, including our own logs. The payload is `userId` / `projectId` / `platformAccessToken` and nothing else — every field platform-issued and bounded, after `projectName` (upstream `z.string().min(2)`, no `.max`) turned out to let one org member's long project name mint an unusable token for every other member. `MAX_ACCESS_TOKEN_LENGTH` 4096 is the belt: measured against the real proxy chain, ~3.3x a real token, and it throws at sign-in where the error page can explain it rather than at a proxy that will not.

`project-key-cache.ts` — the project API key is deliberately *not* in the token: it is a credential with its own lifetime, and sealing it would freeze it for the token's whole life so a rotated key would keep working. Fetched per request, cached 60s, keyed by user **and** project (two users can reach one project with different grants; a project-only key would serve one user's key to the other). Iris measured what the cache buys: **~60ms of platform server time, location-independent**, on a route that does nothing — dominant on tools that otherwise take 20ms, which is why it ships with the change rather than after it. Eviction is rate-limited on the write path, and there is a test that it does not leak — the binding leaked because nothing ever removed it.

## Testing

221 tests, and they cover the two new modules thoroughly. **They do not cover the wiring**: `server.ts` `/api/projects` and `/bind`, and `resolveProjectFromToken`'s cache hit/miss/refusal branches have no tests — which is exactly where the bug in (5) was hiding. Per the auth/sessions norm, a QA pass on the real path — login through restart, against a running server — is a merge condition here, and is worth more than more unit coverage.

## Still on Redis after this

MCP session state (`/mcp`, `/sse`). That is the next one.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces Redis-bound tokens with a sealed, self-describing access token and removes `mcp:auth:binding:` from the OAuth path. OAuth now works without Redis; revocation is enforced by the platform with a 60s user+project cache that is leak-free and collision-safe.

- **Migration**
  - OAuth no longer uses Redis; only MCP sessions still do.
  - `/oauth/token` returns the sealed access token (not a token hash); `expires_in` is 24h.
  - Token payload is only `userId`, `projectId`, and `platformAccessToken`; tokens over 4096 chars are refused at issue.
  - Project API key is fetched per request and cached 60s (keyed by user+project); cache evicts stale entries, prevents key collisions, and `forgetUser` drops all per-user entries.
  - `/oauth/revoke` always returns 200 per RFC 7009 and drops cached keys for that user.
  - `POST /api/projects/{id}/bind` cannot re-point a token; 200 if already scoped (returns only `projectId`), 409 if scoped to a different project.
  - 401s now use `authorization_required` with reauth guidance.

- **Bug Fixes**
  - `/api/projects` opens the sealed bearer before calling the platform; `list-projects` works again.

<sup>Written for commit e1f44e81a408982576668d7931013d381ea90ea2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/insforge-mcp/pull/94?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * OAuth exchanges now issue encrypted access tokens that expire after 24 hours.
  * Tokens securely preserve project and account context without persistent token bindings.
  * Project access information is cached briefly to improve request performance.
* **Bug Fixes**
  * Invalid, expired, oversized, or tampered tokens are rejected consistently.
  * Unauthorized MCP and SSE requests now receive appropriate authorization prompts.
  * Attempts to switch a token between projects are prevented.
  * Revoking access now promptly clears cached project information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
