### PR TITLE
A stale token gets a challenge, not a stack trace

### DIFF
--- a/src/http/server.ts
+++ b/src/http/server.ts
@@ -144,7 +144,32 @@ async function resolveProjectFromToken(token: string): Promise<{
   oauthTokenHash: string;
 } | null> {
   const oauthManager = getOAuthManager();
-  return oauthManager.resolveProjectFromToken(token);
+  try {
+    return await oauthManager.resolveProjectFromToken(token);
+  } catch (error) {
+    // NOTHING here may escape, and that is the whole point of this wrapper.
+    //
+    // Measured on the live slug: a stale bearer — one issued before today's
+    // token format changed — reached Redis, threw MaxRetriesPerRequestError,
+    // and Express answered with a 500 and a raw stack. No WWW-Authenticate.
+    //
+    // "Not a 500" is not the same as "a 401". The challenge header is the ONLY
+    // thing that tells an MCP client to re-run OAuth; a 500 reads as "the
+    // server is broken, give up", so a client holding an old token never
+    // recovers on its own. Iris found this, and it is not hypothetical: the
+    // token format changed three times today and every client holding an
+    // earlier one lands here, as will every existing user at the cutover.
+    //
+    // The honest cost, stated rather than hidden: a genuine infrastructure
+    // fault is now also reported as an authorization failure, which
+    // mislabels it. That is the right trade only because the client's
+    // available action is identical either way — re-authorize — and because a
+    // silent 500 gives it no action at all. The fault is logged at error level
+    // so it stays visible to us even though the client is told something
+    // softer.
+    console.error('[OAuth] Could not resolve a token; answering with a challenge:', error);
+    return null;
+  }
 }
 
 /**


### PR DESCRIPTION
Iris measured this on the live slug, and it is not hypothetical.

```
no Authorization header   401 + WWW-Authenticate      correct
Bearer <stale/garbage>    500, raw Express stack,     wrong
                          MaxRetriesPerRequestError, NO challenge
```

`resolveProjectFromToken` reached Redis, threw, and the throw escaped to Express's default handler.

**"Not a 500" is not the same as "a 401".** The `WWW-Authenticate` header is the only thing that tells an MCP client to re-run OAuth — a 500 reads as *the server is broken, give up*, so a client holding an old token never recovers on its own.

**This is live now.** The token format changed three times today (#82, #87/#89, #94) and each invalidated everything issued before it, so every client holding an earlier one lands on this path — including Tony's, and including every existing user at the cutover. This branch is what decides between "it re-authenticated itself" and "it broke".

## Fixed at the wrapper, not the call sites

```
no header              401 + challenge
stale/garbage bearer   401 + challenge
not even our prefix    401 + challenge
```

Every route already goes through that one function, so a future caller cannot reintroduce the escape.

## The honest cost

A genuine infrastructure fault is now also reported as an authorization failure, which mislabels it. That is the right trade **only** because the client's available action is identical either way — re-authorize — and because a silent 500 gives it no action at all. The fault is logged at error level so it stays visible to us even though the client is told something softer. That reasoning is in the code, not just here.

215 tests.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure stale or invalid bearer tokens return 401 with a WWW-Authenticate challenge instead of 500, so MCP clients re-authenticate automatically and don’t see stack traces.

- **Bug Fixes**
  - Wrapped `resolveProjectFromToken` in try/catch; on error, return null to trigger 401 + `WWW-Authenticate`.
  - Log failures at error level; no errors escape to Express’s default handler.
  - Consistent behavior for no header, stale/garbage tokens, and non-matching prefixes.

<sup>Written for commit bbbf9ba1382773676c10f309199e2a8bade26a52. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/insforge-mcp/pull/95?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

