### PR TITLE
Session ids are credentials, so stop writing them into the logs

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "test:coverage": "vitest run --coverage",
     "lint": "eslint .",
     "format": "prettier --write .",
-    "verify:deploy": "node scripts/verify-deploy.mjs"
+    "verify:deploy": "node scripts/verify-deploy.mjs",
+    "verify:paths": "node scripts/verify-platform-paths.mjs"
   },
   "keywords": [
     "mcp",

--- a/scripts/verify-platform-paths.mjs
+++ b/scripts/verify-platform-paths.mjs
@@ -1,0 +1,80 @@
+#!/usr/bin/env node
+/**
+ * Does every platform path we call actually exist?
+ *
+ * The revoke bug was a 404: the code called `/oauth/v1/revoke` where the
+ * platform serves `/api/oauth/v1/revoke`. It would have failed one hundred
+ * percent of the time in production, and nothing caught it — a stub answers
+ * whatever path the stub was written for, unit tests never leave the process,
+ * and the production probes that did run happened to exercise other routes.
+ * It was found by hand, while moving the call for an unrelated reason.
+ *
+ * So this asks the only question a stub cannot: is this path a route the
+ * platform knows? It does not need credentials and does not need a login,
+ * because the platform distinguishes the two cases by status:
+ *
+ *   401 / 400 / 403   the route exists and refused us. Correct.
+ *   404               the route does not exist. A typo that ships.
+ *
+ * Deliberately NOT a health check — it says nothing about whether the platform
+ * is well, only whether we are calling names it has. Nine seconds, no secrets,
+ * safe to run in CI on every push.
+ *
+ *   node scripts/verify-platform-paths.mjs [apiBase]
+ */
+
+const BASE = (process.argv[2] || process.env.INSFORGE_API_BASE || 'https://api.insforge.dev').replace(
+  /\/+$/,
+  ''
+);
+
+// Every platform path the server calls. A `:id` segment is filled with a
+// well-formed value that no tenant owns — the point is the route, not the row.
+const NOBODY = '00000000-0000-0000-0000-000000000000';
+const PATHS = [
+  { method: 'GET', path: '/auth/v1/profile', from: 'insforge-api.ts validateToken' },
+  { method: 'GET', path: '/organizations/v1', from: 'insforge-api.ts getAllUserProjects' },
+  { method: 'GET', path: `/organizations/v1/${NOBODY}/projects`, from: 'insforge-api.ts' },
+  { method: 'GET', path: `/projects/v1/${NOBODY}`, from: 'insforge-api.ts getProject' },
+  { method: 'GET', path: `/projects/v1/${NOBODY}/access-api-key`, from: 'insforge-api.ts' },
+  { method: 'GET', path: '/api/oauth/v1/authorize', from: 'server.ts /oauth/authorize' },
+  { method: 'POST', path: '/api/oauth/v1/token', from: 'insforge-api.ts exchangeCode' },
+  { method: 'POST', path: '/api/oauth/v1/revoke', from: 'insforge-api.ts revoke' },
+];
+
+const EXISTS = new Set([200, 201, 204, 302, 400, 401, 403, 405, 422]);
+
+const results = await Promise.all(
+  PATHS.map(async (p) => {
+    const started = Date.now();
+    try {
+      const res = await fetch(`${BASE}${p.path}`, {
+        method: p.method,
+        redirect: 'manual',
+        headers: p.method === 'POST' ? { 'content-type': 'application/json' } : {},
+        body: p.method === 'POST' ? '{}' : undefined,
+        signal: AbortSignal.timeout(10_000),
+      });
+      return { ...p, status: res.status, ms: Date.now() - started };
+    } catch (error) {
+      return { ...p, status: 0, error: String(error).slice(0, 60), ms: Date.now() - started };
+    }
+  })
+);
+
+let bad = 0;
+for (const r of results) {
+  const ok = EXISTS.has(r.status);
+  if (!ok) bad++;
+  console.log(
+    `${ok ? 'ok  ' : 'FAIL'}  ${String(r.status).padEnd(3)} ${r.method.padEnd(4)} ${r.path.padEnd(48)} ${r.from}${
+      r.error ? `  ${r.error}` : ''
+    }`
+  );
+}
+
+console.log(
+  `\n${results.length - bad}/${results.length} platform paths exist on ${BASE}` +
+    (bad ? `\n${bad} route(s) the platform does not serve — a request we send will always fail.` : '')
+);
+process.exit(bad ? 1 : 0);

--- a/src/http/server.ts
+++ b/src/http/server.ts
@@ -8,7 +8,7 @@ import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/
 import { SSEServerTransport } from '@modelcontextprotocol/sdk/server/sse.js';
 
 // Local imports
-import { getSessionManager, routeForSessionRequest } from './session-manager.js';
+import { getSessionManager, routeForSessionRequest, sessionFingerprint } from './session-manager.js';
 
 import { getOAuthManager } from './oauth-manager.js';
 import {
@@ -1087,7 +1087,7 @@ app.post(STREAMABLE_HTTP_ENDPOINTS.mcp, async (req: Request, res: Response) => {
   const oauthToken = extractOAuthToken(req);
   const { apiKey: legacyApiKey, apiBaseUrl: legacyApiBaseUrl } = extractLegacyHeaders(req);
 
-  console.log(`[${new Date().toISOString()}] POST ${STREAMABLE_HTTP_ENDPOINTS.mcp} - Session: ${sessionId || 'none'}, Token: ${oauthToken ? tokenFingerprint(oauthToken) : 'none'}`);
+  console.log(`[${new Date().toISOString()}] POST ${STREAMABLE_HTTP_ENDPOINTS.mcp} - Session: ${sessionFingerprint(sessionId)}, Token: ${oauthToken ? tokenFingerprint(oauthToken) : 'none'}`);
 
   let transport: StreamableHTTPServerTransport;
 
@@ -1117,7 +1117,7 @@ app.post(STREAMABLE_HTTP_ENDPOINTS.mcp, async (req: Request, res: Response) => {
 
   if (route === 'use-existing') {
     transport = existingRuntime!.transport;
-    console.log('[Streamable HTTP] Using existing transport for session:', sessionId);
+    console.log('[Streamable HTTP] Using existing transport for session:', sessionFingerprint(sessionId));
     sessionManager.touchSession(sessionId);
   } else if (route === 'not-found') {
     // A session id we do not hold. 404 IS THE ANSWER, and it is the one part of
@@ -1141,7 +1141,7 @@ app.post(STREAMABLE_HTTP_ENDPOINTS.mcp, async (req: Request, res: Response) => {
     // and re-initialize. The status is what the spec and the SDK server agree
     // on; the client's behaviour is Quinn's test, and it is the acceptance for
     // this change rather than a detail after it.
-    console.log('[Streamable HTTP] Unknown session, asking the client to start a new one:', sessionId);
+    console.log('[Streamable HTTP] Unknown session, asking the client to start a new one:', sessionFingerprint(sessionId));
     return res.status(404).json({
       error: 'Session not found',
       error_description:
@@ -1214,13 +1214,13 @@ app.post(STREAMABLE_HTTP_ENDPOINTS.mcp, async (req: Request, res: Response) => {
     transport = new StreamableHTTPServerTransport({
       sessionIdGenerator: () => newSessionId,
       onsessioninitialized: async (initializedSessionId) => {
-        console.log(`[Streamable HTTP] Session initialized: ${initializedSessionId}`);
+        console.log(`[Streamable HTTP] Session initialized: ${sessionFingerprint(initializedSessionId)}`);
       },
     });
 
     try {
       await sessionManager.createSession(newSessionId, projectInfo, transport);
-      console.log('[Streamable HTTP] New session created:', newSessionId);
+      console.log('[Streamable HTTP] New session created:', sessionFingerprint(newSessionId));
 
       const clientInfo = extractClientInfo(req.body);
       getAnalyticsService().trackSessionCreated({
@@ -1258,7 +1258,7 @@ app.get(STREAMABLE_HTTP_ENDPOINTS.mcp, async (req: Request, res: Response) => {
   const authHeader = req.headers['authorization'] as string;
   const sessionManager = getSessionManager();
 
-  console.log(`[${new Date().toISOString()}] GET ${STREAMABLE_HTTP_ENDPOINTS.mcp} - Session: ${sessionId || 'none'}, Auth: ${authHeader ? 'present' : 'missing'}`);
+  console.log(`[${new Date().toISOString()}] GET ${STREAMABLE_HTTP_ENDPOINTS.mcp} - Session: ${sessionFingerprint(sessionId)}, Auth: ${authHeader ? 'present' : 'missing'}`);
 
   if (!sessionId) {
     return res.status(400).json({
@@ -1292,7 +1292,7 @@ app.delete(STREAMABLE_HTTP_ENDPOINTS.mcp, async (req: Request, res: Response) =>
   const sessionId = req.headers['mcp-session-id'] as string;
   const sessionManager = getSessionManager();
 
-  console.log(`[${new Date().toISOString()}] DELETE ${STREAMABLE_HTTP_ENDPOINTS.mcp} - Session: ${sessionId || 'none'}`);
+  console.log(`[${new Date().toISOString()}] DELETE ${STREAMABLE_HTTP_ENDPOINTS.mcp} - Session: ${sessionFingerprint(sessionId)}`);
 
   if (!sessionId) {
     return res.status(400).json({
@@ -1313,7 +1313,7 @@ app.delete(STREAMABLE_HTTP_ENDPOINTS.mcp, async (req: Request, res: Response) =>
   } finally {
     // Always clean up the session, even if handleRequest throws
     await sessionManager.deleteSession(sessionId);
-    console.log(`[Streamable HTTP] Session ${sessionId} closed`);
+    console.log(`[Streamable HTTP] Session ${sessionFingerprint(sessionId)} closed`);
   }
 });
 
@@ -1382,7 +1382,7 @@ app.get(SSE_ENDPOINTS.sse, async (req: Request, res: Response) => {
   const transport = new SSEServerTransport(SSE_ENDPOINTS.messages, res);
   sseTransports.set(transport.sessionId, transport);
 
-  console.log(`[SSE] Session created: ${transport.sessionId}, Project: ${validProjectInfo.projectName}`);
+  console.log(`[SSE] Session created: ${sessionFingerprint(transport.sessionId)}, Project: ${validProjectInfo.projectName}`);
 
   // An idle SSE stream carries no bytes, so the load balancer closes it on its
   // idle timeout and the client sees the connection drop. A comment frame is
@@ -1393,21 +1393,21 @@ app.get(SSE_ENDPOINTS.sse, async (req: Request, res: Response) => {
     try {
       res.write(': keepalive\n\n');
     } catch (error) {
-      console.error(`[SSE] Keepalive write failed for ${transport.sessionId}:`, error);
+      console.error(`[SSE] Keepalive write failed for ${sessionFingerprint(transport.sessionId)}:`, error);
     }
   }, SSE_KEEPALIVE_MS);
   keepAlive.unref();
 
   // Clean up on close
   res.on('close', () => {
-    console.log(`[SSE] Session closed: ${transport.sessionId}`);
+    console.log(`[SSE] Session closed: ${sessionFingerprint(transport.sessionId)}`);
     clearInterval(keepAlive);
     sseTransports.delete(transport.sessionId);
 
     // Clean up the session from SessionManager (async with error handling)
     const sessionManager = getSessionManager();
     sessionManager.deleteSession(transport.sessionId).catch((error) => {
-      console.error(`[SSE] Failed to cleanup session ${transport.sessionId}:`, error);
+      console.error(`[SSE] Failed to cleanup session ${sessionFingerprint(transport.sessionId)}:`, error);
     });
   });
 
@@ -1424,7 +1424,7 @@ app.get(SSE_ENDPOINTS.sse, async (req: Request, res: Response) => {
       oauthTokenHash: validProjectInfo.oauthTokenHash,
     }, transport);
 
-    console.log(`[SSE] MCP server connected for session: ${transport.sessionId}`);
+    console.log(`[SSE] MCP server connected for session: ${sessionFingerprint(transport.sessionId)}`);
 
     getAnalyticsService().trackSessionCreated({
       clientName: undefined, // SSE: clientInfo not available until initialize message
@@ -1436,7 +1436,7 @@ app.get(SSE_ENDPOINTS.sse, async (req: Request, res: Response) => {
       organizationId: validProjectInfo.organizationId,
     });
   } catch (error) {
-    console.error(`[SSE] Failed to create session ${transport.sessionId}:`, error);
+    console.error(`[SSE] Failed to create session ${sessionFingerprint(transport.sessionId)}:`, error);
 
     // Clean up: remove transport from registry
     sseTransports.delete(transport.sessionId);
@@ -1445,7 +1445,7 @@ app.get(SSE_ENDPOINTS.sse, async (req: Request, res: Response) => {
     try {
       await transport.close();
     } catch (closeError) {
-      console.error(`[SSE] Error closing transport ${transport.sessionId}:`, closeError);
+      console.error(`[SSE] Error closing transport ${sessionFingerprint(transport.sessionId)}:`, closeError);
     }
 
     // Attempt to delete any partially created session (ignore errors if it wasn't created)
@@ -1472,7 +1472,7 @@ app.get(SSE_ENDPOINTS.sse, async (req: Request, res: Response) => {
 app.post(SSE_ENDPOINTS.messages, async (req: Request, res: Response) => {
   const sessionId = req.query.sessionId as string;
 
-  console.log(`[${new Date().toISOString()}] POST ${SSE_ENDPOINTS.messages} - Session: ${sessionId || 'none'}`);
+  console.log(`[${new Date().toISOString()}] POST ${SSE_ENDPOINTS.messages} - Session: ${sessionFingerprint(sessionId)}`);
 
   if (!sessionId) {
     return res.status(400).json({
@@ -1589,7 +1589,7 @@ async function startServer() {
           try {
             await transport.close();
           } catch (error) {
-            console.error(`[Shutdown] Error closing SSE transport ${sessionId}:`, error);
+            console.error(`[Shutdown] Error closing SSE transport ${sessionFingerprint(sessionId)}:`, error);
           }
         }
         sseTransports.clear();

--- a/src/http/session-fingerprint.test.ts
+++ b/src/http/session-fingerprint.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import { sessionFingerprint } from './session-manager.js';
+
+describe('sessionFingerprint', () => {
+  it('is stable, so a support report still correlates', () => {
+    const id = 'e6b1d2c4-9f3a-4c77-9c1e-6d5a0f2b1a33';
+    expect(sessionFingerprint(id)).toBe(sessionFingerprint(id));
+  });
+
+  it('does not reveal the id it summarises', () => {
+    const id = 'e6b1d2c4-9f3a-4c77-9c1e-6d5a0f2b1a33';
+    const fp = sessionFingerprint(id);
+    expect(fp).toHaveLength(8);
+    expect(id).not.toContain(fp);
+    expect(sessionFingerprint('e6b1d2c4-9f3a-4c77-9c1e-6d5a0f2b1a34')).not.toBe(fp);
+  });
+
+  it('says "none" rather than "undefined" for a request without one', () => {
+    expect(sessionFingerprint(undefined)).toBe('none');
+    expect(sessionFingerprint(null)).toBe('none');
+    expect(sessionFingerprint('')).toBe('none');
+  });
+});
+
+/**
+ * The guard that matters.
+ *
+ * The bug was never one wrong line — it was that a session id reaches a log
+ * through three different expression shapes, in two files, and a reviewer
+ * checking one shape sees a clean diff. A runtime grep has the same blind spot
+ * from the other side: it only covers the paths the test happened to exercise,
+ * so the SSE cluster stays invisible unless someone opens an SSE session.
+ *
+ * So this reads the source instead of the behaviour: no console line in either
+ * file may pass a session id through anything but sessionFingerprint. It fails
+ * on a shape nobody has thought of yet, which is the failure mode the last two
+ * rounds of this had.
+ */
+describe('no console line prints a raw session id', () => {
+  const files = ['server.ts', 'session-manager.ts'];
+
+  // `${sessionId}`, `${transport.sessionId}`, and a positional `, sessionId)`.
+  const RAW = /\$\{\s*(?:transport\.)?(?:sessionId|newSessionId|initializedSessionId)\s*(?:\|\||\})|,\s*(?:transport\.)?(?:sessionId|newSessionId|initializedSessionId)\s*\)/;
+
+  for (const name of files) {
+    it(`${name} has none`, () => {
+      const src = readFileSync(join(__dirname, name), 'utf8');
+      const offenders = src
+        .split('\n')
+        .map((line, i) => ({ line: line.trim(), n: i + 1 }))
+        .filter(({ line }) => /console\.(log|error|warn|info)/.test(line))
+        .filter(({ line }) => RAW.test(line))
+        .map(({ line, n }) => `${name}:${n}  ${line.slice(0, 100)}`);
+
+      expect(offenders).toEqual([]);
+    });
+  }
+
+  it('the scan is not vacuous — it sees a raw id when there is one', () => {
+    const sample = "console.log(`[Streamable HTTP] Session ${sessionId} closed`);";
+    expect(RAW.test(sample)).toBe(true);
+    const positional = "console.log('[Streamable HTTP] New session created:', newSessionId);";
+    expect(RAW.test(positional)).toBe(true);
+    const sse = 'console.log(`[SSE] Session closed: ${transport.sessionId}`);';
+    expect(RAW.test(sse)).toBe(true);
+    const fingerprinted = 'console.log(`[SSE] Session closed: ${sessionFingerprint(transport.sessionId)}`);';
+    expect(RAW.test(fingerprinted)).toBe(false);
+  });
+});

--- a/src/http/session-manager.ts
+++ b/src/http/session-manager.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'crypto';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
 import { SSEServerTransport } from '@modelcontextprotocol/sdk/server/sse.js';
@@ -5,6 +6,23 @@ import { SESSION_SWEEP_MS } from './config.js';
 import { registerInsforgeTools } from '../shared/tools/index.js';
 import { sdkToolHost } from '../shared/tools/host.js';
 import { PACKAGE_VERSION } from '../shared/version.js';
+
+/**
+ * A session id, safe to log.
+ *
+ * An existing session is served without a token check — Mcp-Session-Id alone
+ * yields the stored project key and full tool access — so it is a bearer
+ * credential and belongs in a log the way a token does: not at all. Manufact
+ * serves its runtime logs over an API, which makes a raw id there a live
+ * credential at rest rather than a routing breadcrumb.
+ *
+ * Deterministic, so the same session prints the same value at every site and a
+ * support report still correlates. Same construction as server.ts’s
+ * tokenFingerprint, deliberately: two equivalent credentials, one treatment.
+ */
+export function sessionFingerprint(sessionId: string | undefined | null): string {
+  return sessionId ? createHash('sha256').update(sessionId).digest('hex').substring(0, 8) : 'none';
+}
 
 /**
  * Sessions, and the honest limit of "stateless".
@@ -267,7 +285,7 @@ export class SessionManager {
       openStreams: 0,
     });
 
-    console.log(`[SessionManager] Session created: ${sessionId}`);
+    console.log(`[SessionManager] Session created: ${sessionFingerprint(sessionId)}`);
     return server;
   }
 
@@ -372,7 +390,7 @@ export class SessionManager {
       openStreams: 0,
     });
 
-    console.log(`[SessionManager] SSE session created: ${sessionId}`);
+    console.log(`[SessionManager] SSE session created: ${sessionFingerprint(sessionId)}`);
     return server;
   }
 
@@ -441,14 +459,14 @@ export class SessionManager {
       await runtime.server.close();
       await runtime.transport.close();
     } catch (error) {
-      console.error(`[SessionManager] Error closing session ${sessionId}:`, error);
+      console.error(`[SessionManager] Error closing session ${sessionFingerprint(sessionId)}:`, error);
     }
     // Outside the try: a close that throws must still drop the entry, or a
     // session that failed to shut down cleanly is held for the life of the
     // process and never swept — the sweep only reaps what it can close.
     this.runtimeSessions.delete(sessionId);
 
-    console.log(`[SessionManager] Session deleted: ${sessionId}`);
+    console.log(`[SessionManager] Session deleted: ${sessionFingerprint(sessionId)}`);
   }
 
   /**


### PR DESCRIPTION
Stacked on `fix/revoke-actually-revokes` so #96 does not need a re-review.

## Why

An existing session is served without a token check, so `Mcp-Session-Id` alone yields the stored project key and full tool access. Measured, not argued — one session created *with* credentials, then reused with none:

```
POST /mcp  tools/list   session id ONLY  -> 200, full tool list
POST /mcp  tools/call   session id ONLY  -> 200
     and the backend received:  x-api-key = <the victim's key>
```

We already fingerprint the OAuth token. We printed the session id in the clear beside it, in the same string. Iris pulled live session ids out of Manufact's runtime logs using an API key, which is what makes this a credential at rest rather than a style point.

## What

21 sites, not the six that a grep for `` `Session: ${sessionId}` `` finds. A session id reaches a log through three expression shapes across two files:

| shape | where | visible to a grep for the first shape? |
|---|---|---|
| `` `${sessionId}` `` / `` `${sessionId \|\| 'none'}` `` | server.ts | yes |
| `console.log('...', sessionId)` | server.ts, incl. the new 404 branch | **no** |
| `` `${transport.sessionId}` `` | the SSE cluster | **no** |

`sessionFingerprint()` lives beside the session code and is the same construction as `tokenFingerprint` — two equivalent credentials, one treatment. Deterministic, so the same session prints the same value at every site and a support report still correlates.

## Verification

Runtime, on **both** transports, because a grep only covers the paths it exercises:

```
streamable: initialize -> tools/list -> GET stream -> dead-id probe (404 branch) -> DELETE
SSE:        GET /sse -> POST /messages -> close

grep for any 36-char UUID in the whole server log:  0 matches
what the log carries instead:  Session created: b37d69ec
                               Session initialized: b37d69ec
                               Session deleted: b37d69ec
                               [SSE] Session created: 4465d50d
```

The test reads the **source**, not the behaviour, for exactly that reason: the SSE sites are invisible to a runtime grep unless someone opens an SSE session. It fails on an expression shape nobody has thought of yet, and carries a meta-test proving it is not vacuous. Both mutations confirmed failing:

```
reintroduce `${sessionId}`                 -> 1 test fails, names server.ts:1316
reintroduce `, newSessionId)` positionally -> 1 test fails
```

238 tests, tsc clean, lint clean.

## Scope

This stops us writing the credential down. It does **not** make a stolen session id useless — binding it to the session's `oauthTokenHash` is separate and still worth doing.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replace raw session IDs in all logs with an 8‑char SHA‑256 fingerprint to prevent credential leaks. Also add a CI-safe path check to catch bad platform routes before deploy.

- **Bug Fixes**
  - Added `sessionFingerprint()` (SHA‑256 → 8‑char hex, returns `none` when missing).
  - Replaced all session-id logging in `server.ts` and `session-manager.ts` (Streamable HTTP, SSE, errors, shutdown, 404) with the fingerprint, including positional args and `${transport.sessionId}`.
  - Added `session-fingerprint.test.ts` to scan source and fail on any console line that prints a raw session ID; includes a meta-test to prove the scan works.
  - Added `scripts/verify-platform-paths.mjs` and `npm run verify:paths` to assert platform routes exist (401/400/403 count as present; 404 fails).

<sup>Written for commit 6e7edca2268f670c1b14d0dee46ed14ffbd02327. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/insforge-mcp/pull/98?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a command to verify that configured platform API routes are available and reachable.
* **Security**
  * Session identifiers are now masked in server and connection logs using short fingerprints instead of raw values.
* **Tests**
  * Added coverage to confirm fingerprint stability, uniqueness, fixed length, missing-value handling, and prevention of accidental identifier exposure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->