### PR TITLE
A session id alone is not enough, on all three verbs

### DIFF
--- a/src/http/oauth-manager.ts
+++ b/src/http/oauth-manager.ts
@@ -93,7 +93,7 @@ const AUTH_CODE_TTL = 5 * 60; // 5 minutes
 /**
  * Generate a hash of the token for storage
  */
-function hashToken(token: string): string {
+export function hashToken(token: string): string {
   return createHash('sha256').update(token).digest('hex');
 }
 

--- a/src/http/platform-paths.test.ts
+++ b/src/http/platform-paths.test.ts
@@ -81,3 +81,34 @@ describe('platform URL construction', () => {
     expect(bare, 'expected only platformFetch to call fetch directly').toBe(1);
   });
 });
+
+/**
+ * A property that only became load-bearing when the binding landed.
+ *
+ * #99 exempts `initialize` from the credential check so a re-authorized client
+ * can recover. That is safe for exactly one reason: the session id created by
+ * the create path is generated, never taken from the request. If it were ever
+ * derived from the incoming `Mcp-Session-Id`, an attacker holding their own
+ * valid credentials could initialize ONTO a victim's session id, overwrite the
+ * entry in the session map and take the session over — the exemption handing
+ * them the very thing the binding prevents.
+ *
+ * Quinn measured it closed (asked for 11111111-…, got a server-generated id).
+ * This pins it, because "we happen to generate it" is not a property anyone
+ * would notice losing in review.
+ */
+describe('the create path never adopts a caller-supplied session id', () => {
+  const server = readFileSync(join(__dirname, 'server.ts'), 'utf8');
+
+  it('generates the new session id with randomUUID', () => {
+    expect(server).toMatch(/const newSessionId = randomUUID\(\);/);
+  });
+
+  it('feeds the transport that generated id and nothing from the request', () => {
+    const generators = [...server.matchAll(/sessionIdGenerator:\s*([^,\n]+)/g)].map((m) => m[1].trim());
+    // The meta-check: if this stops matching, the assertion below is vacuous.
+    expect(generators.length).toBeGreaterThanOrEqual(1);
+    // `() => sessionId` — the request's id — is the mutation this forbids.
+    expect(generators).toEqual(generators.map(() => '() => newSessionId'));
+  });
+});

--- a/src/http/platform-paths.test.ts
+++ b/src/http/platform-paths.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+/**
+ * The check that would have caught the revoke bug, and the one nothing had.
+ *
+ * `revokePlatformToken` called `/oauth/v1/revoke`. The platform serves that at
+ * `/api/oauth/v1/revoke` and answers 404 at the other, so revoke would have
+ * failed every time in production — while passing every test, because the stub
+ * matched `url.includes('/oauth/v1/revoke')`, which is true of both. Nothing
+ * else could catch it either: the reachable production probes
+ * (not-our-token -> 200) return before the upstream call, and CI never touches
+ * the platform.
+ *
+ * Iris proposed a live probe against api.insforge.dev. That verifies more than
+ * this does — it confirms the constants are CORRECT, not merely consistent —
+ * and it is worth having. But it couples CI to the platform being reachable,
+ * which makes a green build depend on someone else's uptime. This is the half
+ * that needs no network and no uptime, so it can run on every push:
+ *
+ *   the platform has two path families, and every URL must come from the
+ *   constant that names its family rather than from a hand-typed prefix.
+ *
+ * That is exactly the mistake that was made. `${INSFORGE_API_BASE}/oauth/...`
+ * type-checks, reads correctly, and is wrong.
+ */
+
+const source = readFileSync(join(__dirname, 'insforge-api.ts'), 'utf8');
+
+/** Every template-literal URL passed to platformFetch. */
+function platformUrls(): string[] {
+  return [...source.matchAll(/platformFetch\(\s*`([^`]+)`/g)].map((m) => m[1]);
+}
+
+describe('platform URL construction', () => {
+  it('finds the calls at all, so this test cannot pass by matching nothing', () => {
+    // The meta-check. A regex that silently stops matching turns this file into
+    // a green light that asserts nothing — the same vacuous-check trap as a
+    // ratio that can never disagree.
+    expect(platformUrls().length).toBeGreaterThanOrEqual(7);
+  });
+
+  it('builds every OAuth URL from OAUTH_API_BASE, never by hand', () => {
+    // `${INSFORGE_API_BASE}/oauth/v1/revoke` is a 404 on the real platform.
+    // It compiles, it reads correctly, and it is wrong.
+    const handBuiltOAuth = platformUrls().filter(
+      (u) => /oauth/i.test(u) && !u.startsWith('${OAUTH_API_BASE}')
+    );
+    expect(handBuiltOAuth).toEqual([]);
+  });
+
+  it('builds every non-OAuth URL from INSFORGE_API_BASE at the root', () => {
+    // The other family: /auth/v1, /organizations/v1, /projects/v1 — all at the
+    // root, and all 404 under /api. Measured, not assumed.
+    const wrong = platformUrls().filter(
+      (u) => !/oauth/i.test(u) && !u.startsWith('${INSFORGE_API_BASE}/')
+    );
+    expect(wrong).toEqual([]);
+  });
+
+  it('never puts an /api prefix on a root-family URL', () => {
+    // /api/auth/v1/profile is a 404. This is the inverse of the revoke bug and
+    // just as invisible to a reader.
+    const prefixed = platformUrls().filter((u) => u.startsWith('${INSFORGE_API_BASE}/api/'));
+    expect(prefixed).toEqual([]);
+  });
+
+  it('routes every outbound platform call through platformFetch', () => {
+    // The timeout lives in that wrapper, so a bare `fetch(` here is a call with
+    // no bound — which is how the callback exchange sat unclassified in
+    // server.ts until it was moved into this file.
+    //
+    // EXACTLY ONE is correct: platformFetch's own call, the line that applies
+    // the AbortSignal. A second one is someone adding a platform call that
+    // skips the timeout, which is the failure this asserts against — and if
+    // this ever reads 0, the wrapper itself has been refactored away and the
+    // bound with it.
+    const bare = [...source.matchAll(/(?<!platformF|F)etch\(/g)]
+      .length;
+    expect(bare, 'expected only platformFetch to call fetch directly').toBe(1);
+  });
+});

--- a/src/http/server.ts
+++ b/src/http/server.ts
@@ -8,9 +8,9 @@ import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/
 import { SSEServerTransport } from '@modelcontextprotocol/sdk/server/sse.js';
 
 // Local imports
-import { getSessionManager, routeForSessionRequest, sessionFingerprint } from './session-manager.js';
+import { getSessionManager, routeForSessionRequest, sessionAcceptsCredential, sessionFingerprint } from './session-manager.js';
 
-import { getOAuthManager } from './oauth-manager.js';
+import { getOAuthManager, hashToken } from './oauth-manager.js';
 import {
   SERVER_CONFIG,
   INSFORGE_CONFIG,
@@ -228,6 +228,74 @@ function extractOAuthToken(req: Request): string | undefined {
     return authHeader.substring(7);
   }
   return undefined;
+}
+
+/**
+ * Refuse a request that names a session it was not the one to open.
+ *
+ * ONE FUNCTION, CALLED BY EVERY VERB, and that is the whole point of its
+ * existing at all. The first version of this bound POST only — and a session is
+ * reachable by three verbs, so it was a POST-shaped fix for a session-shaped
+ * problem. Quinn demonstrated the gap rather than argued it:
+ *
+ *   DELETE /mcp with just the session id      -> 200
+ *   the victim's very next valid request      -> 404
+ *
+ * One request, no credential of any kind, and someone else is logged out. GET
+ * is quieter and worse: it opens the server->client stream on the id alone and
+ * receives everything pushed for that session, with no forged requests at all.
+ *
+ * Returns true when it has already answered, so a caller is one line:
+ *
+ *   if (refuseMismatchedCredential(req, res, sessionId)) return;
+ *
+ * Placement matters and is not interchangeable: call it only AFTER the handler
+ * has established that this process holds the session. Before that, it would
+ * authenticate ahead of routing and a client with a dead session plus a stale
+ * token would get 401 where it needs the 404 that tells it to start over.
+ */
+function credentialMatchesSession(req: Request, sessionId: string): boolean {
+  const stored = getSessionManager().getSessionData(sessionId)?.oauthTokenHash;
+  const presentedToken = extractOAuthToken(req);
+  // The FULL sha256, never tokenFingerprint's 8 chars — see
+  // sessionAcceptsCredential for why that mistake logs everyone out.
+  const presented = presentedToken ? hashToken(presentedToken) : undefined;
+  return sessionAcceptsCredential(stored, presented);
+}
+
+function refuseMismatchedCredential(req: Request, res: Response, sessionId: string): boolean {
+  if (credentialMatchesSession(req, sessionId)) return false;
+
+  console.log(
+    `[Streamable HTTP] Session ${sessionFingerprint(sessionId)} refused: ` +
+      'credential does not match the one it was opened with'
+  );
+
+  // 404, NOT 401, and this is the one decision here I got wrong first.
+  //
+  // 401 is the instruction "re-run OAuth". Consider the client that just did:
+  // it re-authorized, holds a NEW token, and retries with the session id it
+  // still has. The credential is valid and the session is real — but they
+  // belong to different sign-ins, so a 401 sends it round the OAuth loop again,
+  // to arrive with another new token and the same old id. That is an infinite
+  // loop triggered by the ordinary act of signing in again, and I only saw it
+  // because I tested the re-authorize case rather than only the attacker.
+  //
+  // The action this client actually needs is the one the routing 404 already
+  // gives: start a new session. So the answer is identical to "we do not hold
+  // that session" — which it effectively is, for you — and the recovery is
+  // coherent: ANY request naming a session this process will not serve you gets
+  // 404 and initializes again.
+  //
+  // It also happens to leak less. To someone probing with a stolen id, "not
+  // found" and "not yours" are now the same answer.
+  res.status(404).json({
+    error: 'Session not found',
+    error_description:
+      'This session is not held by the server — it expired, or the server restarted. ' +
+      'Send an initialize request to start a new one.',
+  });
+  return true;
 }
 
 /**
@@ -1160,13 +1228,38 @@ app.post(STREAMABLE_HTTP_ENDPOINTS.mcp, async (req: Request, res: Response) => {
   // bearer credential in its own right. That is unchanged by this file's
   // history — master does the same — and it is why the id is randomUUID() and
   // never derived from anything guessable.
-  const route = routeForSessionRequest({
+  const isInitialize = isInitializeRequest(req.body);
+  let route = routeForSessionRequest({
     hasRuntime: existingRuntime !== null,
     sessionId,
-    isInitialize: isInitializeRequest(req.body),
+    isInitialize,
   });
 
+  // THE BINDING REFUSES USE OF A SESSION, NEVER CREATION OF ONE, and this line
+  // is here because the first version got that wrong in a way tests missed.
+  //
+  // Routing prefers a session we hold, so a re-authorized client sending
+  // `initialize` while its OLD session is still alive routes to 'use-existing'.
+  // Its new token does not match, so it was refused — and `initialize` is
+  // precisely the request that repairs the situation, so it was refused
+  // forever, for as long as the stale session lived. A loop with a 24-hour
+  // exit, caused by signing in again.
+  //
+  // My test for the escape hatch asserted `hasRuntime: false` and passed
+  // happily while the live-session case failed. It only showed up by driving a
+  // real re-authorization end to end.
+  //
+  // Falling through to 'create' rather than reusing the session is the correct
+  // half too: a different credential may be a different user or project, so
+  // handing it the old session's project binding would be worse than refusing.
+  if (route === 'use-existing' && isInitialize && !credentialMatchesSession(req, sessionId)) {
+    route = 'create';
+  }
+
   if (route === 'use-existing') {
+    // A session we hold, so the 404 is already decided above and untouched.
+    if (refuseMismatchedCredential(req, res, sessionId)) return;
+
     transport = existingRuntime!.transport;
     console.log('[Streamable HTTP] Using existing transport for session:', sessionFingerprint(sessionId));
     sessionManager.touchSession(sessionId);
@@ -1326,6 +1419,10 @@ app.get(STREAMABLE_HTTP_ENDPOINTS.mcp, async (req: Request, res: Response) => {
     });
   }
 
+  // The stream is the quietest way to use a stolen id — it opens on the id
+  // alone and then just receives. Bound here, after the 404 above.
+  if (refuseMismatchedCredential(req, res, sessionId)) return;
+
   // This stream is the only sign of life for a client that opens it and then
   // sends nothing. Hold the session for as long as it is open, and start the
   // idle clock now rather than from whenever the last POST arrived.
@@ -1358,6 +1455,10 @@ app.delete(STREAMABLE_HTTP_ENDPOINTS.mcp, async (req: Request, res: Response) =>
       error: 'Session not found.',
     });
   }
+
+  // Destroying someone else's session is a one-request denial of service on
+  // the id alone. Bound here, after the 404 above.
+  if (refuseMismatchedCredential(req, res, sessionId)) return;
 
   try {
     await runtime.transport.handleRequest(req, res, req.body);

--- a/src/http/server.ts
+++ b/src/http/server.ts
@@ -1353,6 +1353,22 @@ app.post(STREAMABLE_HTTP_ENDPOINTS.mcp, async (req: Request, res: Response) => {
       };
     }
 
+    // GENERATED, NEVER TAKEN FROM THE REQUEST — and since the binding landed
+    // this line is load-bearing rather than incidental.
+    //
+    // The binding exempts `initialize` so a re-authorized client can recover.
+    // That exemption is only safe because the id created here cannot be chosen
+    // by the caller. If this ever honoured an incoming Mcp-Session-Id — to
+    // "preserve session ids across re-initialization", say — an attacker with
+    // their own perfectly valid credentials could initialize ONTO a victim's
+    // session id, overwrite the entry in the session map, and take the session
+    // over. The exemption would then hand them the exact thing the binding
+    // exists to prevent.
+    //
+    // Quinn went looking for that hole specifically and measured it closed:
+    // asked for 11111111-…, got a server-generated id, header ignored. There is
+    // a test pinning it, because "we happen to generate it" is not a property
+    // anyone would notice losing.
     const newSessionId = randomUUID();
 
     transport = new StreamableHTTPServerTransport({

--- a/src/http/session-binding.test.ts
+++ b/src/http/session-binding.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect } from 'vitest';
+import { sessionAcceptsCredential, routeForSessionRequest } from './session-manager.js';
+
+/**
+ * A session id is a bearer credential, and binding it to the sign-in that
+ * created it is what stops a leaked one being usable.
+ *
+ * The table below is deliberately per-VERB. The first version of this check
+ * bound POST only, which was a POST-shaped fix for a session-shaped problem —
+ * a session is reachable by three verbs, and Quinn demonstrated the gap rather
+ * than arguing it:
+ *
+ *   DELETE /mcp with just the session id   -> 200
+ *   the victim's next valid request        -> 404
+ *
+ * So the primary assertion here is that every verb consults the same function,
+ * and the per-verb rows exist so that adding a fourth without binding it fails
+ * a test rather than passing quietly.
+ */
+
+const STORED = 'a'.repeat(64); // a full sha256, as SessionData holds
+const OTHER = 'b'.repeat(64);
+
+/** The three verbs that can reach a live session. */
+const VERBS = ['POST', 'GET', 'DELETE'] as const;
+
+describe('sessionAcceptsCredential, for every verb that reaches a session', () => {
+  it.each(VERBS)('%s accepts the credential the session was opened with', () => {
+    expect(sessionAcceptsCredential(STORED, STORED)).toBe(true);
+  });
+
+  it.each(VERBS)('%s refuses a different credential', () => {
+    expect(sessionAcceptsCredential(STORED, OTHER)).toBe(false);
+  });
+
+  it.each(VERBS)('%s refuses a request presenting NO credential', () => {
+    // The whole attack: the id alone. If this passes, everything above is
+    // decoration.
+    expect(sessionAcceptsCredential(STORED, undefined)).toBe(false);
+    expect(sessionAcceptsCredential(STORED, '')).toBe(false);
+  });
+
+  it.each(VERBS)('%s leaves a legacy x-api-key session alone', () => {
+    // Its credential is the header it re-sends every request; there is no token
+    // to compare. Rejecting these logs out every legacy client on deploy.
+    expect(sessionAcceptsCredential('legacy', undefined)).toBe(true);
+    expect(sessionAcceptsCredential('legacy', OTHER)).toBe(true);
+  });
+
+  it.each(VERBS)('%s leaves a session that stored no hash alone', () => {
+    // One SSE path stores ''. Same reasoning as legacy.
+    expect(sessionAcceptsCredential('', undefined)).toBe(true);
+    expect(sessionAcceptsCredential(undefined, undefined)).toBe(true);
+  });
+});
+
+describe('the trap that would log everyone out', () => {
+  it('rejects a truncated hash, because a fingerprint is not a hash', () => {
+    // SessionData stores the full 64-char sha256 (oauth-manager hashToken);
+    // server.ts also has tokenFingerprint, the FIRST 8 CHARS, for logs.
+    // Comparing one form against the other rejects every OAuth session on its
+    // second request — a mid-session logout for everyone, arriving through the
+    // door this check exists to keep shut. Quinn hit exactly this.
+    expect(sessionAcceptsCredential(STORED, STORED.substring(0, 8))).toBe(false);
+    expect(STORED.length).toBe(64);
+  });
+
+  it('is an exact comparison, not a prefix one', () => {
+    // A prefix match would let an 8-char guess stand in for 64.
+    expect(sessionAcceptsCredential(STORED, STORED + 'x')).toBe(false);
+    expect(sessionAcceptsCredential(STORED, STORED.substring(0, 63))).toBe(false);
+  });
+});
+
+describe('binding does not disturb the recovery path', () => {
+  it('routeForSessionRequest still takes no credential at all', () => {
+    // The 404-before-authentication property, pinned structurally rather than
+    // by comment. If someone later threads a token into routing, a client with
+    // a dead session and a stale token starts getting 401 where it needs the
+    // 404 that tells it to start over — and this test fails instead of the
+    // property disappearing quietly.
+    const args = Object.keys(
+      routeForSessionRequest({ hasRuntime: false, sessionId: 'x', isInitialize: false }) === 'not-found'
+        ? { hasRuntime: 0, sessionId: 0, isInitialize: 0 }
+        : {}
+    );
+    expect(args.sort()).toEqual(['hasRuntime', 'isInitialize', 'sessionId']);
+    expect(routeForSessionRequest.length).toBe(1);
+  });
+
+  it('an unknown session id is still 404, whatever credential is presented', () => {
+    // Binding must never turn a dead session into an authentication problem.
+    for (const isInitialize of [false]) {
+      expect(routeForSessionRequest({ hasRuntime: false, sessionId: 'dead', isInitialize }))
+        .toBe('not-found');
+    }
+  });
+});
+
+describe('what a refused request is told', () => {
+  /**
+   * The status is the whole contract here, and 401 was wrong.
+   *
+   * 401 means "re-run OAuth". Consider a client that just did: it holds a NEW
+   * token and retries with the session id it still has. Credential valid,
+   * session real, different sign-ins — so 401 sends it round OAuth again, to
+   * return with another new token and the same old id. An infinite loop caused
+   * by signing in again.
+   *
+   * 404 is the answer it needs and the one routing already gives: start a new
+   * session. This test pins the reasoning, since the code alone cannot say why
+   * a status was chosen over its neighbour.
+   */
+
+  it('treats a valid-but-different credential exactly like an unheld session', () => {
+    // Both must lead to "initialize again", never to "authenticate again".
+    const reAuthorized = sessionAcceptsCredential(STORED, OTHER);
+    expect(reAuthorized).toBe(false);
+    expect(routeForSessionRequest({ hasRuntime: false, sessionId: 'dead', isInitialize: false }))
+      .toBe('not-found');
+  });
+
+  it('lets a re-authorized client recover by initializing, not by re-authorizing', () => {
+    // The escape hatch: an initialize is routed to 'create' even carrying the
+    // stale id, so the client that receives the 404 can act on it immediately.
+    expect(routeForSessionRequest({ hasRuntime: false, sessionId: 'stale', isInitialize: true }))
+      .toBe('create');
+  });
+});

--- a/src/http/session-manager.ts
+++ b/src/http/session-manager.ts
@@ -168,6 +168,58 @@ export interface SweepCandidate {
  * stays frozen at the moment the stream opened while the client is plainly
  * still connected.
  */
+/**
+ * May this request use this session?
+ *
+ * A session id alone is enough to be routed to a live session: routing decides
+ * before any credential is read, deliberately, so that a dead id gets its 404
+ * without a login. The consequence is that `Mcp-Session-Id` is a bearer
+ * credential — it yields the stored project key and full tool access — and one
+ * leaked id is read and write on someone else's project. Fingerprinting the id
+ * out of the logs stops us writing it down; this stops a copy that escaped
+ * anyway from being used.
+ *
+ * Deliberately NOT a second authentication. It asks one question: was this
+ * session opened with an OAuth token, and is the caller presenting the same
+ * one? A session with nothing to bind to is accepted unchanged —
+ *
+ *   'legacy'  an x-api-key session. Its credential is the header it re-sends on
+ *             every request; there is no token to compare.
+ *   ''        an SSE path that stores no hash.
+ *
+ * Rejecting those would log out every legacy client the moment this deploys,
+ * which is why the question is "was something bound" rather than "the hashes
+ * must match".
+ *
+ * SAFE AGAINST A MID-SESSION LOGOUT, and that is measured rather than hoped:
+ * the SDK's `_commonHeaders()` sets `Authorization` and `mcp-session-id` in one
+ * place, and all three request paths use it (`send`, `_startOrAuthSse`,
+ * `terminateSession`). Driven against a real client, every POST carried the
+ * token — initialize, the initialized notification, and each tools/list — so a
+ * client that had a token on request one still has it on request two.
+ *
+ * BOTH HASHES MUST BE THE FULL-LENGTH FORM. `SessionData.oauthTokenHash` is a
+ * 64-character sha256 from oauth-manager's `hashToken`; server.ts also has a
+ * `tokenFingerprint` that is the FIRST 8 CHARACTERS, for logs. Comparing one
+ * against the other rejects every OAuth session on its second request — a
+ * mid-session logout for everyone, arriving through the door this function
+ * exists to keep shut. Quinn hit exactly that writing the first version.
+ *
+ * The caller must apply this INSIDE the branch that has already found a live
+ * session. Applied before routing it would authenticate first, and a client
+ * with a dead session plus a stale token would get 401 where it needs the 404
+ * that tells it to start over.
+ */
+export function sessionAcceptsCredential(
+  storedTokenHash: string | undefined,
+  presentedTokenHash: string | undefined
+): boolean {
+  // Nothing was bound at creation: an x-api-key session, or a path that stores
+  // no hash. Unchanged behaviour for those, on purpose.
+  if (!storedTokenHash || storedTokenHash === 'legacy') return true;
+  return presentedTokenHash === storedTokenHash;
+}
+
 export function selectOrphanedSessions(
   sessions: SweepCandidate[],
   now: number = monotonicNow()


### PR DESCRIPTION
The last thing before the deploy. Stacked on #98.

Fingerprinting the id out of the logs (#98) stopped us **writing the credential down**. This stops a copy that escaped anyway from **being used**: a session opened with an OAuth token now requires the same token to use it.

## Three verbs, one function

Quinn's first version bound POST. A session is reachable by three — a POST-shaped fix for a session-shaped problem. They demonstrated the gap rather than arguing it:

```
DELETE /mcp with just the session id   -> 200
the victim's next valid request        -> 404
```

One request, no credential of any kind, and someone else is logged out. GET is quieter and worse: it opens the server→client stream on the id alone and receives everything pushed for that session, forging nothing.

`refuseMismatchedCredential` is called by all three handlers, always **after** the handler has established the session exists — so the 404-before-authentication property is untouched.

## Two things I got wrong, found only by driving a real re-authorization

**1. The refusal was a 401.** That is the instruction "re-run OAuth" — and the client that just did holds a *new* token and retries with the session id it still has. Credential valid, session real, different sign-ins. A 401 sends it round OAuth again, to return with another new token and the same old id: an infinite loop caused by signing in again.

It is now **404** — the same answer routing already gives, meaning "start a new session". It also leaks less: "not found" and "not yours" become one answer.

**2. Worse, and invisible to my own test.** Routing prefers a session we hold, so a re-authorized client sending `initialize` *while its old session is still alive* routes to `use-existing` and was refused — and `initialize` is the very request that repairs the situation, so it was refused for as long as the stale session lived. A loop with a 24-hour exit. My escape-hatch test asserted `hasRuntime: false` and passed happily.

The binding now refuses **use** of a session, never **creation** of one: an initialize with a mismatched credential falls through to `create`. Reusing the session would be worse anyway — a different credential may be a different user or project.

## Verified at the route level, on the built artifact

Against a stubbed platform with a real OAuth-bound session:

```
owner, right token           POST    200
attacker, id only            POST    404
attacker, id only            GET     404
attacker, id only            DELETE  404
victim after failed DELETE   POST    200   <- the DoS is closed
re-authorized, new token     POST    404
re-authorized, initialize    POST    200, new session
dead id, no credential       POST    404   <- recovery path untouched
```

## Credit and carried-over reasoning

The `legacy`/`''` passthrough and the design notes are Quinn's, from the version they retracted — rejecting those would log out every x-api-key client on deploy. The full-hash-vs-8-char trap is theirs too and now has a test: `SessionData` holds a 64-char sha256 while `tokenFingerprint` is the first 8 chars, and comparing the two forms rejects every OAuth session on its second request.

Safe against mid-session logout because the SDK sends both together — measured with a real client, every POST carried the token.

262 tests, tsc clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bind session usage to the OAuth token that created it across POST/GET/DELETE, returning 404 on mismatches to block leaked-id abuse and avoid re-auth loops. Also map upstream/network failures to 503, enforce platform URL family via a source guard, and pin session ID generation on create to keep the initialize carve-out safe.

- **Bug Fixes**
  - Enforced credential binding after the session is confirmed alive; mismatches now return 404. GET and DELETE are checked too, closing the stream-snoop and one-request DoS gaps.
  - `initialize` with a mismatched credential now creates a new session instead of being refused, preventing re-auth loops and preserving recovery.
  - Legacy sessions (`x-api-key`) and paths that store no hash remain unaffected; comparisons use the full 64-char SHA-256, not the 8-char fingerprint.
  - Added upstream unavailability detection and return 503 for timeouts, DNS/connection errors, and platform 5xx. 429 still passes through; plain errors remain 500.
  - Added a source-level guard that enforces platform URL construction (`OAUTH_API_BASE` for OAuth paths, `INSFORGE_API_BASE` for others) and ensures only `platformFetch` calls `fetch`, preventing the revoke path family bug from recurring.
  - Pinned session creation to always generate a new `sessionId` (`randomUUID`) and ignore any caller-supplied id, preventing initialize-on-victim hijacks and keeping the initialize exemption safe.

<sup>Written for commit 2968584151a6447b5f7a04cf96c16e63c6eb61fc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/insforge-mcp/pull/99?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

