### PR TITLE
The repair page clears both scopes, not one

### DIFF
--- a/src/http/oauth-error-response.test.ts
+++ b/src/http/oauth-error-response.test.ts
@@ -193,3 +193,27 @@ describe('the repair clears every scope it can live in', () => {
     expect(add).toBeGreaterThan(lastRemove);
   });
 });
+
+describe('the page says where to run the commands', () => {
+  /**
+   * Project scope is CWD-relative, so both removes miss a project entry
+   * written somewhere else. Blair measured it:
+   *
+   *   entry in ~/projA/.mcp.json, run from ~/projB
+   *     remove <url> -y      "No matching servers found"
+   *     remove <url> -g -y   "No matching servers found"
+   *     projA entry          STILL THERE
+   *
+   * Both results are honest — there is nothing to remove where they looked —
+   * and the user is still broken. That is the same silent-partial-success one
+   * directory over, and the only fix available to a page is to say where to
+   * stand. A sentence, not a command.
+   */
+
+  it('tells the reader which directory to run them from', () => {
+    for (const error of ['invalid_client', 'invalid_request']) {
+      const { message } = humanFormOf({ error }, MCP_URL);
+      expect(message).toMatch(/project directory/);
+    }
+  });
+});

--- a/src/http/oauth-error-response.test.ts
+++ b/src/http/oauth-error-response.test.ts
@@ -67,6 +67,7 @@ describe('every browser-visible failure says what to do', () => {
       expect(action).toEqual([
         'codex mcp logout insforge',
         `npx add-mcp remove ${MCP_URL} -y`,
+        `npx add-mcp remove ${MCP_URL} -g -y`,
         'npx add-mcp https://mcp.insforge.dev/mcp',
       ]);
       expect(action.join(' ')).not.toContain('@insforge/install');
@@ -84,9 +85,14 @@ describe('every browser-visible failure says what to do', () => {
     // rebuilds the SAME mcpOAuth key and picks the dead registration back up,
     // so the commands alone repair nothing. Clearing the client's saved
     // authorisation is the step that works, and it comes first.
-    const [logout, remove, add] = reconnectCommand(MCP_URL);
+    const [logout, removeProject, removeGlobal, add] = reconnectCommand(MCP_URL);
     expect(logout).toContain('logout');
-    expect(remove).toContain('remove');
+    expect(removeProject).toContain('remove');
+    // TWO removes: add-mcp's -g means "instead of project-level", not "as
+    // well as", so one command clears one scope and reports success while the
+    // other copy survives. Blair measured that on a machine with both.
+    expect(removeGlobal).toContain('remove');
+    expect(removeGlobal).toContain('-g');
     expect(add).toContain(MCP_URL);
   });
 
@@ -114,6 +120,7 @@ describe('every browser-visible failure says what to do', () => {
     expect(reconnectCommand(slug)).toEqual([
       'codex mcp logout insforge',
       `npx add-mcp remove ${slug} -y`,
+      `npx add-mcp remove ${slug} -g -y`,
       `npx add-mcp ${slug}`,
     ]);
     // The two add-mcp commands are host-derived; the codex one names the
@@ -152,5 +159,37 @@ describe('prefersHtml', () => {
 
   it('is true for a browser', () => {
     expect(prefersHtml(asBrowser)).toBe(true);
+  });
+});
+
+describe('the repair clears every scope it can live in', () => {
+  /**
+   * A server can be defined in two scopes at once, and add-mcp's remove clears
+   * exactly one per invocation:
+   *
+   *   .option("-g, --global", "Remove from global configs INSTEAD OF
+   *                            project-level")
+   *
+   * "instead of" is the defect. The page printed one remove, it reported
+   * "Removed 1 server", and the other copy survived — so a stuck user
+   * re-added and stayed stuck, told it had worked. Adding `-g` instead of the
+   * plain form would only move which scope is missed.
+   */
+
+  const URL_ = 'https://keen-pulse-fsjr9.run.mcp-use.com/mcp';
+
+  it('issues a remove for BOTH scopes, not one', () => {
+    const removes = reconnectCommand(URL_).filter((c) => c.includes('remove'));
+    expect(removes).toHaveLength(2);
+    expect(removes.some((c) => !c.includes('-g'))).toBe(true);  // project scope
+    expect(removes.some((c) => c.includes('-g'))).toBe(true);   // global scope
+  });
+
+  it('removes before it re-adds, in that order', () => {
+    // Re-adding first would rebuild the entry the removal is meant to clear.
+    const cmds = reconnectCommand(URL_);
+    const lastRemove = cmds.map((c) => c.includes('remove')).lastIndexOf(true);
+    const add = cmds.findIndex((c) => c.includes('add-mcp') && !c.includes('remove'));
+    expect(add).toBeGreaterThan(lastRemove);
   });
 });

--- a/src/http/oauth-error-response.ts
+++ b/src/http/oauth-error-response.ts
@@ -187,7 +187,8 @@ export function humanFormOf(body: OAuthErrorBody, mcpUrl: string): HumanForm {
           'authorisation for this server that this server no longer recognises, and it will keep ' +
           'reusing it until you clear it. In Claude Code: run /mcp, pick this server, and choose ' +
           'Clear authentication. In Codex: run the first command below. Then reconnect with the ' +
-          'last one.',
+          'last one. Run the commands from the project directory where you use InsForge — one of ' +
+          'them only looks there.',
         action: reconnectCommand(mcpUrl),
       };
 
@@ -202,7 +203,9 @@ export function humanFormOf(body: OAuthErrorBody, mcpUrl: string): HumanForm {
           'The address your app asked us to send you back to is not the one it registered — ' +
           'usually because it restarted on a different port. Clearing the saved authorisation is ' +
           'what fixes it. In Claude Code: run /mcp, pick this server, and choose Clear ' +
-          'authentication. In Codex: run the first command below. Then reconnect with the last.',
+          'authentication. In Codex: run the first command below. Then reconnect with the last. ' +
+          'Run the commands from the project directory where you use InsForge — one of them only ' +
+          'looks there.',
         action: reconnectCommand(mcpUrl),
       };
 

--- a/src/http/oauth-error-response.ts
+++ b/src/http/oauth-error-response.ts
@@ -139,9 +139,33 @@ export function reconnectCommand(mcpUrl: string): string[] {
   // chunk-2LJORNPV.js). So passing the URL is exact, host-derived by
   // construction, and cannot drift the way a copy of their inference rule
   // would.
+  // TWO removes, not one, because a server can be defined in two scopes at
+  // once and each command clears exactly one of them. From add-mcp@2.0.0's own
+  // source:
+  //
+  //   program.command("remove <query>")
+  //     .option("-g, --global", "Remove from global configs INSTEAD OF
+  //                              project-level")
+  //
+  // "instead of" is the whole problem. Blair demonstrated the consequence on a
+  // machine with the server defined in both places:
+  //
+  //   npx add-mcp remove <url> -y
+  //     -> "Removed 1 server from 1 agent"      the project entry
+  //     -> the user-level entry is STILL THERE
+  //
+  // So the page printed one command, the command reported success, and the
+  // stuck user re-added and stayed stuck — with a cheerful confirmation that
+  // the repair had worked. That is the same silent-partial-success shape this
+  // page exists to end, committed by the page itself.
+  //
+  // Adding `-g` INSTEAD would not fix it either; it just moves which scope is
+  // missed. The honest repair is both, and it is harmless to run either one
+  // when that scope holds nothing — add-mcp reports zero removed and exits 0.
   return [
     'codex mcp logout insforge',
     `npx add-mcp remove ${mcpUrl} -y`,
+    `npx add-mcp remove ${mcpUrl} -g -y`,
     `npx add-mcp ${mcpUrl}`,
   ];
 }


### PR DESCRIPTION
Blair found that #90's repair instructions — live on the error page right now — half-perform.

A server can be defined in two scopes at once, and from add-mcp@2.0.0's own source:

```
program.command("remove <query>")
  .option("-g, --global", "Remove from global configs INSTEAD OF project-level")
```

**"instead of" is the defect.** Measured on a machine with both:

```
npx add-mcp remove <url> -y
  -> "Removed 1 server from 1 agent"    the project entry
  -> the user-level entry is STILL THERE
```

So the page printed one command, the command reported success, and the stuck user re-added and stayed stuck — with a cheerful confirmation that the repair had worked. That is exactly the silent-partial-success shape this page exists to end, committed by the page itself.

## Why not `-g`

Blair suggested `-g` or an all-scopes sweep. I checked the flag rather than taking it: **`-g` *instead* would only move which scope is missed**, and there is no all-scopes flag on `remove`. Both commands is the honest repair, and running either against a scope that holds nothing is harmless — add-mcp reports zero removed and exits 0.

Four commands now rather than three. That's the cost of the page being true, and a stuck user following four correct steps beats three that report success and leave them stuck.

## Tests

Updated at all three sites that pinned the old triple, plus new coverage that **both** scopes get a remove, and that the removes come **before** the re-add — re-adding first would rebuild the entry the removal exists to clear.

271 tests pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the OAuth error page repair instructions to clear the MCP server from both project and global scopes, and tells users to run them from the project directory. This prevents partial “success” from scope or CWD mismatches.

- **Bug Fixes**
  - Reconnect flow runs both removals: `npx add-mcp remove <url> -y` and `npx add-mcp remove <url> -g -y`, then re-add; reason: `add-mcp@2.0.0`’s `-g` removes global instead of project, so both are required.
  - Error text now says to run the commands from the project directory where InsForge is used, since project removal is CWD-relative.
  - Tests ensure two removes appear before the add and that the directory guidance is present.

<sup>Written for commit 5d5dd582578c761aa71ff94778dd27842a0ff101. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/insforge-mcp/pull/101?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved OAuth reconnection by clearing both project-level and global server configurations before reconnecting.
  - Ensured cleanup commands run before the server is re-added, including when URLs are derived from the host.
  - Clarified that reconnection commands should be run from the project directory.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->