### PR TITLE
The repair page's last branch still recommended the no-op

### DIFF
--- a/src/http/oauth-error-response.test.ts
+++ b/src/http/oauth-error-response.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { humanFormOf, prefersHtml, reconnectCommand, sendOAuthError } from './oauth-error-response.js';
+import { humanFormOf, prefersHtml, reconnectCommand, sendOAuthError, PKCE_REQUIRED_PAGE } from './oauth-error-response.js';
 
 const MCP_URL = 'https://mcp.insforge.dev/mcp';
 
@@ -125,13 +125,13 @@ describe('every browser-visible failure says what to do', () => {
   // required it. That is this same bug pointed the other way — a test naming one
   // remedy stops distinguishing the cases where that remedy is not the remedy.
   // Blair caught it against the rendered page.
+  //
+  // The table is now exactly the codes that mean a stale registration, which is
+  // the only thing clearing repairs. Everything else moved to the table below —
+  // see the comment there for why that direction is the load-bearing one.
   it.each([
     ['invalid_client', undefined],
     ['invalid_request', undefined],
-    ['unsupported_response_type', 'Only response_type=code is supported'],
-    ['token_exchange_failed', undefined],
-    ['weird_new_code', undefined],
-    ['weird_new_code', 'the disk melted'],
   ])('%s (description: %s) never prints the commands without the step that makes them work', (error, error_description) => {
     const { message, action } = humanFormOf({ error, error_description }, MCP_URL);
     // Asserted, not guarded. This read `if (!action) return` — meant for
@@ -152,15 +152,58 @@ describe('every browser-visible failure says what to do', () => {
   // clearing must not be handed the clearing instruction. Without this the two
   // tables are just a list and nothing stops `access_denied` drifting back into
   // the default branch, which is how it got the wrong advice in the first place.
+  //
+  // The unknown codes belong here rather than above, and that is the decision
+  // this table encodes. What can actually reach the catch-all is enumerable:
+  // the platform answers every rejection it makes at its own authorize endpoint
+  // with a 400 JSON body rather than a redirect, so those never re-enter this
+  // server; the single code it puts on our callback is `access_denied`. Nothing
+  // arriving here is a stale registration, so nothing arriving here should be
+  // told to clear one — least of all a stranger during a cutover.
   it.each([
     ['server_error', undefined],
     ['access_denied', undefined],
     ['access_denied', 'The user denied the request'],
+    ['unsupported_response_type', 'Only response_type=code is supported'],
+    ['login_required', undefined],
+    ['invalid_scope', 'Client not authorized for scopes: mcp:write'],
+    ['temporarily_unavailable', undefined],
+    ['weird_new_code', undefined],
+    ['weird_new_code', 'the disk melted'],
   ])('%s (description: %s) is not told to clear a registration that works', (error, error_description) => {
     const { message, action } = humanFormOf({ error, error_description }, MCP_URL);
     expect(action).toBeUndefined();
     expect(message).not.toMatch(/Clear authentication/);
     expect(message).not.toMatch(/add(ing)? it back/i);
+  });
+
+  // The table above cannot tell a dedicated branch from the catch-all, because
+  // the catch-all is now command-free too and satisfies every negative in it.
+  // Deleting either branch left the suite green — so these pin the thing that
+  // makes them branches at all: they name what happened in their own words.
+  it.each([
+    ['access_denied', 'This sign-in was not approved'],
+    ['unsupported_response_type', 'Your client asked for a sign-in this server does not support'],
+  ])('%s says what happened in its own words, not the catch-all\'s', (error, heading) => {
+    const human = humanFormOf({ error }, MCP_URL);
+    expect(human.heading).toBe(heading);
+    expect(human.heading).not.toBe(humanFormOf({ error: 'a_code_with_no_branch' }, MCP_URL).heading);
+  });
+
+  it('tells the PKCE case its own cause, not the port one', () => {
+    // `invalid_request` is emitted from several sites with different causes.
+    // The branch copy is right for the redirect_uri mismatch and false here —
+    // a request without code_challenge has nothing to do with a restarted port,
+    // and clearing a registration does not add PKCE to a client. This is the
+    // site override, kept in this file so it is testable at all; the overrides
+    // written inline at their call sites are covered by nothing.
+    expect(PKCE_REQUIRED_PAGE.action).toBeUndefined();
+    expect(PKCE_REQUIRED_PAGE.message).toMatch(/PKCE/);
+    expect(PKCE_REQUIRED_PAGE.message).toMatch(/code_challenge/);
+    expect(PKCE_REQUIRED_PAGE.message).not.toMatch(/different port/);
+    expect(PKCE_REQUIRED_PAGE.message).not.toMatch(/Clear authentication/);
+    // The branch it overrides asserts the cause it must not inherit.
+    expect(humanFormOf({ error: 'invalid_request' }, MCP_URL).message).toMatch(/different port/);
   });
 
   it('treats a blank description as no description', () => {
@@ -183,11 +226,11 @@ describe('every browser-visible failure says what to do', () => {
       { error: 'weird_new_code', error_description: 'the platform said no' },
       MCP_URL
     );
-    expect(message).toContain('the platform said no. In Claude Code');
+    expect(message).toContain('the platform said no. Start it again');
     // A description that already punctuates itself is not given a second stop.
     expect(
       humanFormOf({ error: 'weird_new_code', error_description: 'it broke.' }, MCP_URL).message
-    ).toContain('it broke. In Claude Code');
+    ).toContain('it broke. Start it again');
   });
 
   it('names the host the person is actually talking to, in BOTH commands', () => {
@@ -229,21 +272,22 @@ describe('every browser-visible failure says what to do', () => {
     // Deliberately no longer the description ALONE. It is the only account of
     // what actually failed, so it is kept and it comes first — but it used to
     // arrive with the reconnect commands and no way to make them work, which
-    // is the same trap as the fallback sentence it sits beside.
+    // is the same trap as the fallback sentence it sits beside. It now closes
+    // with the one instruction that is true for every unknown code.
     const { message } = humanFormOf(
       { error: 'weird_new_code', error_description: 'the disk melted' },
       MCP_URL
     );
     expect(message).toMatch(/^the disk melted/);
-    expect(message).toMatch(/Clear authentication/);
+    expect(message).toMatch(/Start it again from your editor or client.$/);
   });
 
   it('still says something when there is no description either', () => {
-    // The lead sentence and the repair, both — a length check alone passed
+    // The lead sentence and a next step, both — a length check alone passed
     // happily on the old text, whose 40+ characters were the no-op advice.
     const { message } = humanFormOf({ error: 'weird_new_code' }, MCP_URL);
     expect(message).toMatch(/^The sign-in did not complete\./);
-    expect(message).toMatch(/Clear authentication/);
+    expect(message).toMatch(/Start it again from your editor or client\.$/);
   });
 });
 

--- a/src/http/oauth-error-response.test.ts
+++ b/src/http/oauth-error-response.test.ts
@@ -119,12 +119,16 @@ describe('every browser-visible failure says what to do', () => {
   // and `npx add-mcp remove` writes a different file entirely, so commands
   // printed without the menu step leave the user in the loop the page exists
   // to end.
+  // The table is codes whose remedy IS clearing. `access_denied` was in it and
+  // should never have been: nothing is stale when someone cancels, so asserting
+  // /Clear authentication/ over it did not merely allow the wrong advice, it
+  // required it. That is this same bug pointed the other way — a test naming one
+  // remedy stops distinguishing the cases where that remedy is not the remedy.
+  // Blair caught it against the rendered page.
   it.each([
     ['invalid_client', undefined],
     ['invalid_request', undefined],
     ['unsupported_response_type', 'Only response_type=code is supported'],
-    ['access_denied', undefined],
-    ['access_denied', 'The user denied the request'],
     ['token_exchange_failed', undefined],
     ['weird_new_code', undefined],
     ['weird_new_code', 'the disk melted'],
@@ -142,6 +146,37 @@ describe('every browser-visible failure says what to do', () => {
     // phrasing — it was selling remove-and-re-add as the remedy, which reads as
     // the friendlier instruction in any wording someone reaches for next.
     expect(message).not.toMatch(/add(ing)? it back/i);
+  });
+
+  // And the other half of the same property: a code whose remedy is NOT
+  // clearing must not be handed the clearing instruction. Without this the two
+  // tables are just a list and nothing stops `access_denied` drifting back into
+  // the default branch, which is how it got the wrong advice in the first place.
+  it.each([
+    ['server_error', undefined],
+    ['access_denied', undefined],
+    ['access_denied', 'The user denied the request'],
+  ])('%s (description: %s) is not told to clear a registration that works', (error, error_description) => {
+    const { message, action } = humanFormOf({ error, error_description }, MCP_URL);
+    expect(action).toBeUndefined();
+    expect(message).not.toMatch(/Clear authentication/);
+    expect(message).not.toMatch(/add(ing)? it back/i);
+  });
+
+  it('does not run the platform\'s sentence into ours', () => {
+    // The forwarded description is not ours and carries no punctuation
+    // guarantee. Joined with a bare space, "The user denied the request" ran
+    // straight into "In Claude Code: run /mcp" as one sentence. Our own literal
+    // fallbacks all end in a full stop, so nothing in the fixtures showed it.
+    const { message } = humanFormOf(
+      { error: 'weird_new_code', error_description: 'the platform said no' },
+      MCP_URL
+    );
+    expect(message).toContain('the platform said no. In Claude Code');
+    // A description that already punctuates itself is not given a second stop.
+    expect(
+      humanFormOf({ error: 'weird_new_code', error_description: 'it broke.' }, MCP_URL).message
+    ).toContain('it broke. In Claude Code');
   });
 
   it('names the host the person is actually talking to, in BOTH commands', () => {

--- a/src/http/oauth-error-response.test.ts
+++ b/src/http/oauth-error-response.test.ts
@@ -163,6 +163,17 @@ describe('every browser-visible failure says what to do', () => {
     expect(message).not.toMatch(/add(ing)? it back/i);
   });
 
+  it('treats a blank description as no description', () => {
+    // A present-but-blank `error_description` is truthy, so it used to skip the
+    // fallback and render ". In Claude Code: ..." — a sentence opening with a
+    // full stop. Reachable by hand: ?error=x&error_description=%20.
+    for (const blank of [' ', '   ', '\t']) {
+      const { message } = humanFormOf({ error: 'weird_new_code', error_description: blank }, MCP_URL);
+      expect(message).toMatch(/^The sign-in did not complete\./);
+      expect(message).not.toMatch(/^\s*\./);
+    }
+  });
+
   it('does not run the platform\'s sentence into ours', () => {
     // The forwarded description is not ours and carries no punctuation
     // guarantee. Joined with a bare space, "The user denied the request" ran

--- a/src/http/oauth-error-response.test.ts
+++ b/src/http/oauth-error-response.test.ts
@@ -107,6 +107,35 @@ describe('every browser-visible failure says what to do', () => {
     }
   });
 
+  // The property, over every code rather than over the two branches someone
+  // remembered. The test above asserted the right thing about the wrong set:
+  // it named `invalid_client` and `invalid_request` explicitly, so the default
+  // branch went on telling people to remove the server and add it back — the
+  // remedy this same file documents as a no-op — for as long as nobody looked.
+  // A test that lists the cases it imagines stops covering the one it does not.
+  //
+  // Quinn traced why the distinction matters: only the Claude Code TUI action
+  // deletes the mcpOAuth record. `claude mcp remove` swallows its own failure
+  // and `npx add-mcp remove` writes a different file entirely, so commands
+  // printed without the menu step leave the user in the loop the page exists
+  // to end.
+  it.each([
+    ['invalid_client', undefined],
+    ['invalid_request', undefined],
+    ['unsupported_response_type', 'Only response_type=code is supported'],
+    ['access_denied', undefined],
+    ['access_denied', 'The user denied the request'],
+    ['token_exchange_failed', undefined],
+    ['weird_new_code', undefined],
+    ['weird_new_code', 'the disk melted'],
+  ])('%s (description: %s) never prints the commands without the step that makes them work', (error, error_description) => {
+    const { message, action } = humanFormOf({ error, error_description }, MCP_URL);
+    if (!action) return; // server_error offers no commands, so it needs no clearing step
+    expect(message).toMatch(/Clear authentication/);
+    // And it must not recommend the substitute that repairs nothing.
+    expect(message).not.toMatch(/adding it back is the usual remedy/);
+  });
+
   it('names the host the person is actually talking to, in BOTH commands', () => {
     // On the Manufact slug it must say the slug, or someone follows the
     // instruction and reconnects to the box we are migrating off.
@@ -142,9 +171,17 @@ describe('every browser-visible failure says what to do', () => {
     expect(human.message).toMatch(/different port/);
   });
 
-  it('falls back to the description for a code it has never seen', () => {
-    expect(humanFormOf({ error: 'weird_new_code', error_description: 'the disk melted' }, MCP_URL).message)
-      .toBe('the disk melted');
+  it('leads with the description for a code it has never seen', () => {
+    // Deliberately no longer the description ALONE. It is the only account of
+    // what actually failed, so it is kept and it comes first — but it used to
+    // arrive with the reconnect commands and no way to make them work, which
+    // is the same trap as the fallback sentence it sits beside.
+    const { message } = humanFormOf(
+      { error: 'weird_new_code', error_description: 'the disk melted' },
+      MCP_URL
+    );
+    expect(message).toMatch(/^the disk melted/);
+    expect(message).toMatch(/Clear authentication/);
   });
 
   it('still says something when there is no description either', () => {

--- a/src/http/oauth-error-response.test.ts
+++ b/src/http/oauth-error-response.test.ts
@@ -130,10 +130,18 @@ describe('every browser-visible failure says what to do', () => {
     ['weird_new_code', 'the disk melted'],
   ])('%s (description: %s) never prints the commands without the step that makes them work', (error, error_description) => {
     const { message, action } = humanFormOf({ error, error_description }, MCP_URL);
-    if (!action) return; // server_error offers no commands, so it needs no clearing step
+    // Asserted, not guarded. This read `if (!action) return` — meant for
+    // server_error, which is not in this table and so never reached it. What it
+    // would actually have done is let a branch that silently LOST its commands
+    // pass the test written to protect them: exactly the it-cannot-fail shape
+    // that let the default branch drift in the first place. Caught in review by
+    // john-bot and coderabbit independently.
+    expect(action).toBeDefined();
     expect(message).toMatch(/Clear authentication/);
-    // And it must not recommend the substitute that repairs nothing.
-    expect(message).not.toMatch(/adding it back is the usual remedy/);
+    // Broader than the one sentence that was removed. The defect was never that
+    // phrasing — it was selling remove-and-re-add as the remedy, which reads as
+    // the friendlier instruction in any wording someone reaches for next.
+    expect(message).not.toMatch(/add(ing)? it back/i);
   });
 
   it('names the host the person is actually talking to, in BOTH commands', () => {
@@ -185,7 +193,11 @@ describe('every browser-visible failure says what to do', () => {
   });
 
   it('still says something when there is no description either', () => {
-    expect(humanFormOf({ error: 'weird_new_code' }, MCP_URL).message.length).toBeGreaterThan(40);
+    // The lead sentence and the repair, both — a length check alone passed
+    // happily on the old text, whose 40+ characters were the no-op advice.
+    const { message } = humanFormOf({ error: 'weird_new_code' }, MCP_URL);
+    expect(message).toMatch(/^The sign-in did not complete\./);
+    expect(message).toMatch(/Clear authentication/);
   });
 });
 

--- a/src/http/oauth-error-response.test.ts
+++ b/src/http/oauth-error-response.test.ts
@@ -206,6 +206,28 @@ describe('every browser-visible failure says what to do', () => {
     expect(humanFormOf({ error: 'invalid_request' }, MCP_URL).message).toMatch(/different port/);
   });
 
+  it.each([
+    ['a repeated query parameter', ['a', 'b']],
+    ['a single repeated value', ['only']],
+    ['a number', 42],
+    ['an object', { nested: true }],
+    ['null', null],
+  ])('survives %s where a string was declared', (_label, error_description) => {
+    // The TYPE says string; the VALUE comes from req.query, where a repeated
+    // parameter is an array and the callback forwards it with a cast. So
+    // `?error=x&error_description=a&error_description=b` reached `.trim()` and
+    // threw — express then rendered its own stack trace, file paths and all, to
+    // the person this page exists to help. Anyone could craft that URL.
+    const body = { error: 'weird_new_code', error_description } as unknown as {
+      error: string;
+      error_description?: string;
+    };
+    expect(() => humanFormOf(body, MCP_URL)).not.toThrow();
+    const { message } = humanFormOf(body, MCP_URL);
+    // Falls through to the generic sentence rather than rendering the junk.
+    expect(message).toMatch(/^The sign-in did not complete\./);
+  });
+
   it('treats a blank description as no description', () => {
     // A present-but-blank `error_description` is truthy, so it used to skip the
     // fallback and render ". In Claude Code: ..." — a sentence opening with a

--- a/src/http/oauth-error-response.ts
+++ b/src/http/oauth-error-response.ts
@@ -171,6 +171,34 @@ export function reconnectCommand(mcpUrl: string): string[] {
 }
 
 /**
+ * The step that actually clears a stuck client, in the words the page uses.
+ *
+ * One constant rather than a sentence copied into each branch. It has been
+ * corrected three times now — the installer that was the wrong product, the
+ * reconnect that repaired nothing on its own, the second remove for the scope
+ * `-g` misses — and every correction had to find each copy. The branch below
+ * that nobody remembered to update is what this constant exists to prevent.
+ *
+ * DO NOT simplify this to "remove the server and add it back". That reads as
+ * the friendlier instruction and it repairs nothing. Quinn traced the shipped
+ * Claude Code v2.1.220 binary: the menu action reaches
+ * `clearServerTokensFromLocalStorage` with `preserveClientRegistration` falsy,
+ * which deletes the whole `mcpOAuth` record including `clientId` — that is why
+ * the TUI step is a real repair. The two substitutes a person would reach for
+ * instead are not. `claude mcp remove` calls the same function behind a catch
+ * that swallows its failure, and both records survive it (measured on seeded
+ * files in an isolated HOME). `npx add-mcp remove` cannot help in principle: it
+ * writes `~/.mcp.json`, and the OAuth record lives in `~/.claude.json`.
+ *
+ * So of the three remedies a stuck user might try, exactly one clears anything,
+ * and it is the one that cannot be pasted from a code block.
+ */
+const CLEARING_INSTRUCTION =
+  'In Claude Code: run /mcp, pick this server, and choose Clear authentication. In Codex: run ' +
+  'the first command below. Then reconnect with the last one. Run the commands from the project ' +
+  'directory where you use InsForge — one of them only looks there.';
+
+/**
  * What to tell a person, given the machine-readable error.
  *
  * Pure and exported so the wording is testable without standing up express —
@@ -185,10 +213,8 @@ export function humanFormOf(body: OAuthErrorBody, mcpUrl: string): HumanForm {
         message:
           'Nothing is wrong with your account and no data was lost. Your editor has saved an ' +
           'authorisation for this server that this server no longer recognises, and it will keep ' +
-          'reusing it until you clear it. In Claude Code: run /mcp, pick this server, and choose ' +
-          'Clear authentication. In Codex: run the first command below. Then reconnect with the ' +
-          'last one. Run the commands from the project directory where you use InsForge — one of ' +
-          'them only looks there.',
+          'reusing it until you clear it. ' +
+          CLEARING_INSTRUCTION,
         action: reconnectCommand(mcpUrl),
       };
 
@@ -202,10 +228,8 @@ export function humanFormOf(body: OAuthErrorBody, mcpUrl: string): HumanForm {
         message:
           'The address your app asked us to send you back to is not the one it registered — ' +
           'usually because it restarted on a different port. Clearing the saved authorisation is ' +
-          'what fixes it. In Claude Code: run /mcp, pick this server, and choose Clear ' +
-          'authentication. In Codex: run the first command below. Then reconnect with the last. ' +
-          'Run the commands from the project directory where you use InsForge — one of them only ' +
-          'looks there.',
+          'what fixes it. ' +
+          CLEARING_INSTRUCTION,
         action: reconnectCommand(mcpUrl),
       };
 
@@ -218,12 +242,20 @@ export function humanFormOf(body: OAuthErrorBody, mcpUrl: string): HumanForm {
       };
 
     default:
+      // The branch #101 did not reach, still telling people to remove the
+      // server and add it back — the one remedy this file had already measured
+      // as a no-op, printed under the commands that cannot carry it out. An
+      // unknown code is not a reason to give worse advice than a known one, and
+      // this branch is reachable: /oauth/callback forwards the PLATFORM's error
+      // code verbatim (server.ts) when there is no registered redirect to bounce
+      // it back to, so the codes arriving here are ones we do not choose.
+      //
+      // The description, when the platform sent one, is kept and led with — it
+      // is the only account of what actually failed. What changes is that it no
+      // longer arrives without the step that makes the commands beneath it work.
       return {
         heading: 'Sign-in could not be completed',
-        message:
-          body.error_description ||
-          'The sign-in did not complete. Removing the InsForge MCP server from your client ' +
-          'and adding it back is the usual remedy.',
+        message: `${body.error_description || 'The sign-in did not complete.'} ${CLEARING_INSTRUCTION}`,
         action: reconnectCommand(mcpUrl),
       };
   }

--- a/src/http/oauth-error-response.ts
+++ b/src/http/oauth-error-response.ts
@@ -192,6 +192,28 @@ export function reconnectCommand(mcpUrl: string): string[] {
  *
  * So of the three remedies a stuck user might try, exactly one clears anything,
  * and it is the one that cannot be pasted from a code block.
+ *
+ * AND THE PERSON IS THE ONLY ONE WHO CAN DO IT — the client will not heal on a
+ * retry, by design. Max read the same binary from the other end:
+ *
+ *   fEs(name, cfg)                       menu action, no options -> deletes the
+ *                                        whole record            (Quinn's read)
+ *   fEs(e, t, {preserveClientRegistration: A})   the AUTOMATIC re-auth path
+ *     A = !a?.clientId || _ === u || a.redirectUri === E
+ *     returning user, unchanged callback port -> A is TRUE -> registration KEPT
+ *
+ * So the dead id survives every automatic re-authentication as long as the
+ * client's loopback port is stable, which for a returning user it is. Retrying
+ * cannot fix this; that is the mechanism, not a guess about SDK behaviour.
+ *
+ * One dead end this closes, so nobody spends a day on it: v2.0.0 had a
+ * self-heal — `invalid_client` whose description contained "Client not found"
+ * deleted the clientId and re-registered — and that string does not appear
+ * anywhere in 2.1.220. Rewording our error to trigger it fails twice over,
+ * because the branch is gone AND our 400 is rendered at `/oauth/authorize` to a
+ * BROWSER. The client process is sat on its localhost callback and never reads
+ * that response. No wording we choose can reach it, which is exactly why the
+ * page talks to the person instead.
  */
 const CLEARING_INSTRUCTION =
   'In Claude Code: run /mcp, pick this server, and choose Clear authentication. In Codex: run ' +
@@ -290,7 +312,11 @@ export function humanFormOf(body: OAuthErrorBody, mcpUrl: string): HumanForm {
       // longer arrives without the step that makes the commands beneath it work.
       return {
         heading: 'Sign-in could not be completed',
-        message: `${endsSentence(body.error_description || 'The sign-in did not complete.')} ${CLEARING_INSTRUCTION}`,
+        // `.trim() ||` rather than `||`: a present-but-blank description is
+        // truthy, so it skipped the fallback and rendered a lone leading full
+        // stop. Reachable by hand-crafting `?error=x&error_description=%20` on
+        // the callback, which makes it cheaper to handle than to argue about.
+        message: `${endsSentence(body.error_description?.trim() || 'The sign-in did not complete.')} ${CLEARING_INSTRUCTION}`,
         action: reconnectCommand(mcpUrl),
       };
   }

--- a/src/http/oauth-error-response.ts
+++ b/src/http/oauth-error-response.ts
@@ -236,6 +236,29 @@ function endsSentence(text: string): string {
 }
 
 /**
+ * The missing-PKCE page, as a value rather than an object literal at the site.
+ *
+ * `invalid_request` is emitted from several places with different causes, and
+ * the branch copy belongs to one of them — the redirect_uri mismatch, where
+ * "your app restarted on a different port" is true. At the PKCE site it is
+ * false, which is worse than an unhelpful remedy: it is a wrong cause, and it
+ * sends someone looking for a problem they do not have.
+ *
+ * So the site overrides. It lives HERE rather than inline in server.ts for the
+ * one reason that matters: page copy in this file is unit-testable, and the
+ * overrides written inline at their call sites are not tested by anything.
+ * Copy is Blair's.
+ */
+export const PKCE_REQUIRED_PAGE: HumanForm = {
+  heading: 'Your client skipped a required security step',
+  message:
+    'Sign-ins here need PKCE, and this request arrived without it. Nothing is wrong with ' +
+    'your account and there is nothing to undo. The fix is in the client: it needs to send ' +
+    'a code_challenge using S256.',
+  action: undefined,
+};
+
+/**
  * What to tell a person, given the machine-readable error.
  *
  * Pure and exported so the wording is testable without standing up express —
@@ -293,31 +316,55 @@ export function humanFormOf(body: OAuthErrorBody, mcpUrl: string): HumanForm {
       //
       // Copy is Blair's, who caught that the default branch was pinning the
       // wrong remedy here.
+      // "Not approved" rather than "you cancelled": RFC 6749 §4.1.2.1 defines
+      // this as the resource owner OR the authorization server denying, so the
+      // cancel wording is false in the policy case and sends someone hunting
+      // for a mistake they did not make. It also matches the family already
+      // here — "This sign-in took too long", "did not come back complete".
       return {
-        heading: 'You cancelled this sign-in',
-        message: 'You cancelled the sign-in. Start it again and approve to continue.',
+        heading: 'This sign-in was not approved',
+        message:
+          'Nothing was changed and nothing is wrong with your account. Start it again from ' +
+          'your editor or client, and approve the request to continue.',
+      };
+
+    case 'unsupported_response_type':
+      // One emitting site (the response_type check at authorize), so a branch
+      // rather than an override. Clearing cannot fix a client that asks for the
+      // wrong response type, and there is nothing for the reader to undo.
+      return {
+        heading: 'Your client asked for a sign-in this server does not support',
+        message:
+          'This server only issues authorization codes, and your client asked for something ' +
+          'else. Nothing is wrong with your account and there is nothing to undo. The fix is ' +
+          'in the client, so if someone else ships it, that is who to report it to.',
       };
 
     default:
-      // The branch #101 did not reach, still telling people to remove the
-      // server and add it back — the one remedy this file had already measured
-      // as a no-op, printed under the commands that cannot carry it out. An
-      // unknown code is not a reason to give worse advice than a known one, and
-      // this branch is reachable: /oauth/callback forwards the PLATFORM's error
-      // code verbatim (server.ts) when there is no registered redirect to bounce
-      // it back to, so the codes arriving here are ones we do not choose.
+      // No commands, and deliberately no clearing instruction.
       //
-      // The description, when the platform sent one, is kept and led with — it
-      // is the only account of what actually failed. What changes is that it no
-      // longer arrives without the step that makes the commands beneath it work.
+      // This branch used to recommend remove-and-re-add (a measured no-op), and
+      // the first fix replaced it with the clearing instruction — which is the
+      // same error with a better remedy attached to the wrong cause. What
+      // actually arrives here decides it, and it is enumerable rather than
+      // arguable. The platform's /oauth/v1/authorize answers every rejection it
+      // makes with a 400 JSON body instead of a redirect, so those never re-enter
+      // this server at all; the one code it does put on our callback is
+      // `access_denied`, which has its own branch above. Everything else landing
+      // here is a code we do not choose and have never seen.
+      //
+      // None of them is a stale registration — that is `invalid_client`, which
+      // has its own branch — so telling a stranger to clear a working sign-in
+      // during a cutover would be this file's own bug pointed a third way.
+      //
+      // The description, when the platform sent one, is kept and led with: it is
+      // the only account of what actually failed. `.trim() ||` because a
+      // present-but-blank description is truthy and skipped the fallback,
+      // rendering a lone leading full stop — reachable by hand-crafting
+      // `?error=x&error_description=%20` on the callback.
       return {
         heading: 'Sign-in could not be completed',
-        // `.trim() ||` rather than `||`: a present-but-blank description is
-        // truthy, so it skipped the fallback and rendered a lone leading full
-        // stop. Reachable by hand-crafting `?error=x&error_description=%20` on
-        // the callback, which makes it cheaper to handle than to argue about.
-        message: `${endsSentence(body.error_description?.trim() || 'The sign-in did not complete.')} ${CLEARING_INSTRUCTION}`,
-        action: reconnectCommand(mcpUrl),
+        message: `${endsSentence(body.error_description?.trim() || 'The sign-in did not complete.')} Start it again from your editor or client.`,
       };
   }
 }

--- a/src/http/oauth-error-response.ts
+++ b/src/http/oauth-error-response.ts
@@ -199,6 +199,21 @@ const CLEARING_INSTRUCTION =
   'directory where you use InsForge — one of them only looks there.';
 
 /**
+ * Terminate a sentence we did not write before another one follows it.
+ *
+ * The only text this is ever applied to is the platform's forwarded
+ * `error_description`, which is outside our control and carries no punctuation
+ * guarantee — "The user denied the request" is a real one. Joined with a bare
+ * space it runs straight into the next sentence: "...denied the request In
+ * Claude Code: run /mcp". Our own literal fallbacks end in a full stop, which
+ * is exactly why the seam was invisible until Blair read the rendered copy.
+ */
+function endsSentence(text: string): string {
+  const trimmed = text.trim();
+  return /[.!?:;]$/.test(trimmed) ? trimmed : `${trimmed}.`;
+}
+
+/**
  * What to tell a person, given the machine-readable error.
  *
  * Pure and exported so the wording is testable without standing up express —
@@ -241,6 +256,26 @@ export function humanFormOf(body: OAuthErrorBody, mcpUrl: string): HumanForm {
           'the details below are what support will ask for.',
       };
 
+    case 'access_denied':
+      // Nothing is stale here — they cancelled. Clearing the authorisation
+      // would destroy a registration that works and land them back on the same
+      // consent screen, so this branch exists to keep the repair instruction
+      // away from the one code we know does not need it.
+      //
+      // Reachable on exactly one path, and the flip makes it likelier rather
+      // than rarer: /oauth/callback bounces a platform error back to the
+      // client's own redirect_uri when it can open the auth state, and only
+      // renders this page when it cannot (server.ts). A cancel whose state
+      // cookie is missing or host-scoped to the other hostname is precisely
+      // what a cutover window produces.
+      //
+      // Copy is Blair's, who caught that the default branch was pinning the
+      // wrong remedy here.
+      return {
+        heading: 'You cancelled this sign-in',
+        message: 'You cancelled the sign-in. Start it again and approve to continue.',
+      };
+
     default:
       // The branch #101 did not reach, still telling people to remove the
       // server and add it back — the one remedy this file had already measured
@@ -255,7 +290,7 @@ export function humanFormOf(body: OAuthErrorBody, mcpUrl: string): HumanForm {
       // longer arrives without the step that makes the commands beneath it work.
       return {
         heading: 'Sign-in could not be completed',
-        message: `${body.error_description || 'The sign-in did not complete.'} ${CLEARING_INSTRUCTION}`,
+        message: `${endsSentence(body.error_description || 'The sign-in did not complete.')} ${CLEARING_INSTRUCTION}`,
         action: reconnectCommand(mcpUrl),
       };
   }

--- a/src/http/oauth-error-response.ts
+++ b/src/http/oauth-error-response.ts
@@ -266,6 +266,21 @@ export const PKCE_REQUIRED_PAGE: HumanForm = {
  * would be least likely to assert.
  */
 export function humanFormOf(body: OAuthErrorBody, mcpUrl: string): HumanForm {
+  // The type says string. The VALUE comes from `req.query`, where a repeated
+  // parameter is parsed as an array — `?error_description=a&error_description=b`
+  // arrives as `['a','b']`, and the callback forwards it with a cast, which is a
+  // claim rather than a conversion. So `.trim()` threw a TypeError and express
+  // rendered its own stack trace, with file paths, to the person the page exists
+  // to help. Anyone can craft that URL.
+  //
+  // Normalised here rather than at the callback because this helper is what
+  // every browser-visible error goes through — fixing the one caller that
+  // happens to be reachable today is the mistake this file was written to stop.
+  // Anything that is not a string is treated as absent, so the generic page is
+  // what a hostile query gets.
+  const description =
+    typeof body.error_description === 'string' ? body.error_description : undefined;
+
   switch (body.error) {
     case 'invalid_client':
       return {
@@ -364,7 +379,7 @@ export function humanFormOf(body: OAuthErrorBody, mcpUrl: string): HumanForm {
       // `?error=x&error_description=%20` on the callback.
       return {
         heading: 'Sign-in could not be completed',
-        message: `${endsSentence(body.error_description?.trim() || 'The sign-in did not complete.')} Start it again from your editor or client.`,
+        message: `${endsSentence(description?.trim() || 'The sign-in did not complete.')} Start it again from your editor or client.`,
       };
   }
 }

--- a/src/http/server.ts
+++ b/src/http/server.ts
@@ -29,7 +29,7 @@ import {
 import { renderProjectSelectionPage } from './templates/project-selection.js';
 import { getAnalyticsService, extractClientInfo } from './analytics.js';
 import { sendUnauthorized, protectedResourceMetadata } from './auth-challenge.js';
-import { sendOAuthError } from './oauth-error-response.js';
+import { sendOAuthError, PKCE_REQUIRED_PAGE } from './oauth-error-response.js';
 import {
   mintClientId,
   readClientId,
@@ -519,13 +519,24 @@ app.get(OAUTH_ENDPOINTS.authorize, async (req: Request, res: Response) => {
     // instead of at registration: reject where the caller is listening, not
     // where only a browser can see it. The MCP client reads this response; it
     // never reads the one at the end of the flow.
-    return sendOAuthError(req, res, 400, {
-      error: 'invalid_request',
-      error_description:
-        'code_challenge is required. This server advertises S256 as its only ' +
-        'code_challenge_method and issues authorization codes that carry their own state, ' +
-        'so PKCE is what makes a code safe to accept.',
-    });
+    // An override, because `invalid_request` is emitted from several sites with
+    // different causes and the branch copy belongs to a different one: it tells
+    // the reader their app restarted on a different port, which is true at the
+    // redirect_uri site below and false here. Blair enumerated the sites and
+    // caught this asserting a cause that cannot be the cause.
+    return sendOAuthError(
+      req,
+      res,
+      400,
+      {
+        error: 'invalid_request',
+        error_description:
+          'code_challenge is required. This server advertises S256 as its only ' +
+          'code_challenge_method and issues authorization codes that carry their own state, ' +
+          'so PKCE is what makes a code safe to accept.',
+      },
+      PKCE_REQUIRED_PAGE
+    );
   }
 
   if (response_type !== 'code') {

--- a/src/http/templates/oauth-error.test.ts
+++ b/src/http/templates/oauth-error.test.ts
@@ -42,3 +42,34 @@ describe('renderOAuthErrorPage', () => {
     expect(html).not.toContain('</title><script>');
   });
 });
+
+describe('the escape survives a value that is not a string', () => {
+  /**
+   * The deployed build rendered express's own stack trace — absolute paths and
+   * the dependency tree — to anyone who crafted
+   * `?error=x&error_description=a&error_description=b`, because express parses
+   * a repeated parameter as an array and `.replace` is not a function on one.
+   *
+   * `humanFormOf` normalises that field now, so this is the second layer. It is
+   * here because this renderer owns every browser-visible field and trusted its
+   * input, which is one level below where anyone was looking.
+   */
+  it.each([
+    ['an array', ['a', 'b']],
+    ['a number', 42],
+    ['null', null],
+    ['undefined', undefined],
+    ['an object', { toString: () => 'obj' }],
+  ])('renders rather than throwing for %s', (_label, value) => {
+    const render = () =>
+      renderOAuthErrorPage({ heading: value as unknown as string, message: 'm' });
+    expect(render).not.toThrow();
+    expect(render()).toContain('<!DOCTYPE html>');
+  });
+
+  it('still escapes when the value is a string', () => {
+    const html = renderOAuthErrorPage({ heading: 'h', message: '<script>alert(1)</script>' });
+    expect(html).not.toContain('<script>');
+    expect(html).toContain('&lt;script&gt;');
+  });
+});

--- a/src/http/templates/oauth-error.ts
+++ b/src/http/templates/oauth-error.ts
@@ -105,8 +105,27 @@ export function renderOAuthErrorPage(options: OAuthErrorPageOptions): string {
 </html>`;
 }
 
+/**
+ * Escape, and survive a value that is not a string.
+ *
+ * The type says string and the DEPLOYED build proved that is a claim rather
+ * than a fact. `?error=x&error_description=a&error_description=b` gives express
+ * an array, the callback forwards it with a cast, and this function's
+ * `.replace` threw — so the page rendered express's own error instead: a stack
+ * trace with absolute paths and the dependency tree, to anyone who crafts that
+ * URL, unauthenticated. Max found it live on the slug.
+ *
+ * `humanFormOf` now normalises that field, which closes the known route. This
+ * coercion is here because this function is the one that OWNS every
+ * browser-visible field and it trusted its input — the layer below where anyone
+ * was looking. Fixing only the caller I know about is how the same crash
+ * survives in the next field someone adds.
+ *
+ * `String(...)` rather than a throw or an empty string: a page that renders
+ * "a,b" is ugly and harmless, and the failure this replaces was neither.
+ */
 function escapeHtml(text: string): string {
-  return text
+  return String(text)
     .replace(/&/g, '&amp;')
     .replace(/</g, '&lt;')
     .replace(/>/g, '&gt;')


### PR DESCRIPTION
## TL;DR

The repair page's `default` branch still tells people to remove the MCP server and add it back — the one remedy this file already documents as repairing nothing. #101 fixed that wording in `invalid_client` and `invalid_request` and did not reach the third branch. One shared constant now, plus the property test that would have caught it.

Not a cutover blocker: the flip cohort hits `invalid_client`, which is correct today. This is the branch behind it.

## Why it matters

`/oauth/callback` forwards the **platform's** error code verbatim when there is no registered redirect to bounce it back to (`server.ts`), so the codes landing on `default` are ones we do not choose, and a browser is the only thing that ever sees them.

Quinn traced the shipped Claude Code v2.1.220 binary and settled what actually repairs a stuck client:

```
menu "Clear authentication" -> clearServerTokensFromLocalStorage(...)
                            -> preserveClientRegistration falsy -> deletes the whole
                               mcpOAuth record, clientId included        <- a real repair

claude mcp remove           -> calls the same function behind a catch that swallows
                               the failure; both records survive        <- no-op
npx add-mcp remove          -> writes ~/.mcp.json; the record is in ~/.claude.json
                                                                        <- cannot help
```

One of the three remedies a person would try clears anything, and it is the one that cannot be pasted from a code block. The `default` branch was recommending one of the other two.

## The change

- `CLEARING_INSTRUCTION` — one constant, used by every branch that prints commands. The sentence has been corrected three times (wrong installer, reconnect-repairs-nothing, the second remove for the scope `-g` misses) and each correction had to find every copy. The comment carries Quinn's trace as the reason it must not be "simplified" back to remove-and-re-add, which is the friendlier-reading instruction that silently stops repairing anything.
- The upstream `error_description` is **kept and led with** — it is the only account of what actually failed. What changes is that it no longer arrives with the reconnect commands and no way to make them work.
- The wording test asserted the right property over the wrong set: it named the two branches someone remembered. It is now a property over every code, with and without a description.

## Verification

- Reverted against the old text, the new property fails **7 ways** (every default-branch case, with and without a description). A green test I have not watched fail is not evidence.
- Full suite green: 280 passed, 20 files. `npm run build` clean, `npm run lint` 0 errors.

## The trade-off, stated

For a code like `access_denied` (someone clicked Deny), "clear your saved authorisation" is more than they need — the honest remedy is "try again". I did not gate the instruction by code, because the branch exists precisely for codes we cannot classify, and the branch **already printed the reconnect commands for all of them**. This adds the step that makes those commands work rather than adding advice where there was none. If we want per-code triage there, that is a separate change with a list of codes behind it.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the repair page so it never recommends the remove‑and‑re‑add no‑op, adds per‑code copy (incl. PKCE), removes commands from the catch‑all, and hardens the HTML escaper to prevent stack‑trace leaks from non‑string values.

- **Bug Fixes**
  - Shared `CLEARING_INSTRUCTION` used only for stale-registration cases: `invalid_client` and redirect-URI `invalid_request`; excluded for `access_denied`, `server_error`, and all unknown codes.
  - New branches: `access_denied` (“This sign-in was not approved”) and `unsupported_response_type` (client asked for an unsupported flow). Both avoid clearing and commands.
  - PKCE: added `PKCE_REQUIRED_PAGE` and a server override for `invalid_request` without `code_challenge`; explains PKCE and shows no clearing.
  - `default` no longer prints commands or clearing; leads with the platform description (trims blanks, normalizes punctuation via `endsSentence`) and tells the user to restart sign-in.
  - Tests cover all codes: assert no-clearing where it’s wrong, forbid any “add it back” phrasing, pin new branch headings, and verify PKCE/blank-description/punctuation seams.
  - Normalize non-string `error_description` values (arrays, numbers, objects, null) to avoid a crash and stack-trace leak; fall back to the generic message with a 400 response.
  - Renderer hardening: `escapeHtml` now coerces non-string inputs to safe strings to prevent unauthenticated stack-trace disclosure; tests cover arrays, numbers, null, and HTML escaping.

<sup>Written for commit 18f09a4fd03125ecaa66d43e19ab63e56db6e9c8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/insforge-mcp/pull/103?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OAuth error messages with clearer authentication-clearing and reconnection guidance.
  * Added specific messaging for cancelled sign-ins and unsupported response types.
  * Preserved valid platform-provided descriptions while normalizing punctuation and handling malformed or blank text.
  * Removed ineffective recommendations to remove and re-add connections.
  * Added dedicated guidance when required PKCE security information is missing.
  * Expanded OAuth error handling with consistent, actionable recovery guidance across known and unknown failures.
  * Prevented OAuth error pages from failing when unexpected heading values are provided.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->