### PR TITLE
refresh_token: stop every client dying after an hour

### DIFF
--- a/src/http/config.ts
+++ b/src/http/config.ts
@@ -95,8 +95,17 @@ export const OAUTH_CONFIG = {
   /** Scopes supported by this MCP server */
   supportedScopes: ['mcp:read', 'mcp:write', 'project:select'],
 
-  /** Grant types supported */
-  grantTypes: ['authorization_code'],
+  /**
+   * Grant types supported.
+   *
+   * `refresh_token` is advertised here, which is what puts it in
+   * `grant_types_supported` on the AS metadata and in the default registration
+   * response — the two places a client looks before it will ever try to renew.
+   * Advertising it is therefore part of the feature, not documentation of it: a
+   * client that does not see it here keeps signing in through a browser every
+   * hour even though the endpoint would answer.
+   */
+  grantTypes: ['authorization_code', 'refresh_token'],
 
   /** Response types supported */
   responseTypes: ['code'],

--- a/src/http/config.ts
+++ b/src/http/config.ts
@@ -221,6 +221,32 @@ export function accessTokenKey(): Buffer {
   return deriveAccessTokenKey(INSFORGE_CONFIG.clientSecret);
 }
 
+/**
+ * And a fifth, for the refresh token.
+ *
+ * Fifth purpose, fifth label. It seals a credential that outlives the access
+ * token by thirty times, so it is the one whose key most needs to be unrelated
+ * to the others: a refresh token is what an attacker would rather have.
+ *
+ * Note for whoever counts these next: rotating INSFORGE_CLIENT_SECRET now
+ * invalidates FIVE things rather than four, and the refresh token is the one
+ * that makes that rotation user-visible for longer — an access token dies in an
+ * hour anyway, but a refresh token someone was relying on for a month dies with
+ * the rotation and sends them back through a browser.
+ */
+const REFRESH_TOKEN_KEY_LABEL = 'mcp-refresh-token-v1';
+
+export function deriveRefreshTokenKey(clientSecret: string): Buffer {
+  if (!clientSecret) {
+    throw new Error('INSFORGE_CLIENT_SECRET is required: the refresh token key is derived from it');
+  }
+  return createHmac('sha256', clientSecret).update(REFRESH_TOKEN_KEY_LABEL).digest();
+}
+
+export function refreshTokenKey(): Buffer {
+  return deriveRefreshTokenKey(INSFORGE_CONFIG.clientSecret);
+}
+
 // ============================================================================
 // Redis Configuration
 // ============================================================================

--- a/src/http/credential-guards.test.ts
+++ b/src/http/credential-guards.test.ts
@@ -1,0 +1,175 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import http from 'node:http';
+import type { AddressInfo } from 'node:net';
+
+/**
+ * The two guards that say "the platform rejected OUR credentials" rather than
+ * "your sign-in expired", driven through the real routes.
+ *
+ * These had NO coverage. QA proved it the only way that counts: she disabled
+ * each guard in turn and the suite stayed green at 314 both times. Both fixes
+ * were correct and both would have reverted silently — a refactor of either
+ * error-handling block puts a user back on "sign in again" during a rotation,
+ * with nothing going red. This exact class had already shipped once in this
+ * file, which is what makes an untested version of the fix unacceptable rather
+ * than merely untidy.
+ *
+ * Nothing here is unit-testable: the distinction lives in a route handler, and a
+ * test of an extracted helper would keep passing after someone deleted the call
+ * to it — the same shape as asserting a function's return value while the
+ * response drops the field. So this drives the routes, with the PLATFORM stubbed
+ * and only its answer changing between cases.
+ */
+
+/** The two shapes the platform's token endpoint actually returns, verbatim. */
+const PLATFORM_RESPONSES = {
+  // Our client_id/secret are wrong for this deployment — a botched rotation.
+  invalid_client: { status: 401, body: { error: 'invalid_client', message: 'Invalid client credentials' } },
+  // Our credentials are fine; the code or refresh token is not.
+  invalid_grant: { status: 400, body: { error: 'invalid_grant', message: 'Invalid authorization code' } },
+} as const;
+
+let platform: http.Server;
+let platformShape: keyof typeof PLATFORM_RESPONSES = 'invalid_client';
+let server: http.Server;
+let baseUrl: string;
+let issueRefreshToken: typeof import('./refresh-token.js').issueRefreshToken;
+let refreshTokenKey: typeof import('./config.js').refreshTokenKey;
+
+beforeAll(async () => {
+  // The platform stub, on an ephemeral port, so the env can point at it before
+  // the server module is imported and reads its config.
+  platform = http.createServer((_req, res) => {
+    const { status, body } = PLATFORM_RESPONSES[platformShape];
+    res.writeHead(status, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify(body));
+  });
+  await new Promise<void>((resolve) => platform.listen(0, '127.0.0.1', resolve));
+  const platformPort = (platform.address() as AddressInfo).port;
+
+  process.env.INSFORGE_API_BASE = `http://127.0.0.1:${platformPort}`;
+  process.env.INSFORGE_CLIENT_ID = 'test-client-id';
+  process.env.INSFORGE_CLIENT_SECRET = 'test-client-secret';
+  process.env.MCP_SERVER_URL = 'http://127.0.0.1';
+
+  // Imported AFTER the env is set, and importing no longer starts a listener —
+  // see the entry-point guard at the bottom of server.ts, which exists so this
+  // file can exist.
+  const [{ app }, refreshToken, config] = await Promise.all([
+    import('./server.js'),
+    import('./refresh-token.js'),
+    import('./config.js'),
+  ]);
+  issueRefreshToken = refreshToken.issueRefreshToken;
+  refreshTokenKey = config.refreshTokenKey;
+
+  server = app.listen(0, '127.0.0.1');
+  await new Promise<void>((resolve) => server.once('listening', () => resolve()));
+  baseUrl = `http://127.0.0.1:${(server.address() as AddressInfo).port}`;
+});
+
+afterAll(async () => {
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+  await new Promise<void>((resolve) => platform.close(() => resolve()));
+});
+
+/** A refresh token of ours, sealed with the key this deployment derives. */
+function ourRefreshToken(): string {
+  return issueRefreshToken(
+    { userId: 'u1', platformRefreshToken: 'platform-refresh', projectId: 'p1' },
+    refreshTokenKey()
+  );
+}
+
+async function postRefresh(token: string) {
+  return fetch(`${baseUrl}/oauth/token`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: new URLSearchParams({ grant_type: 'refresh_token', refresh_token: token }),
+  });
+}
+
+/**
+ * The callback needs a state the server will open, so this walks the real flow:
+ * register a client, start an authorize (which sets the sealed cookie and hands
+ * the platform a handle), then call back with a junk code carrying both.
+ *
+ * That is also exactly the container-side pre-flight from the cutover checklist
+ * — the check that proves the CONTAINER holds the right secret rather than
+ * proving the secret in someone's clipboard does.
+ */
+async function callbackWithJunkCode() {
+  const registered = await fetch(`${baseUrl}/oauth/register`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ redirect_uris: ['http://127.0.0.1:9999/cb'] }),
+  }).then((r) => r.json() as Promise<{ client_id: string }>);
+
+  const authorize = await fetch(
+    `${baseUrl}/oauth/authorize?response_type=code&client_id=${encodeURIComponent(registered.client_id)}` +
+      `&redirect_uri=${encodeURIComponent('http://127.0.0.1:9999/cb')}` +
+      `&code_challenge=${'a'.repeat(43)}&code_challenge_method=S256`,
+    { redirect: 'manual' }
+  );
+
+  const cookie = (authorize.headers.get('set-cookie') ?? '').split(';')[0];
+  const handle = new URL(authorize.headers.get('location') ?? '', 'http://x').searchParams.get('state');
+
+  return fetch(`${baseUrl}/oauth/callback?code=junk&state=${encodeURIComponent(handle ?? '')}`, {
+    headers: { cookie, accept: 'text/html' },
+  });
+}
+
+describe('the platform rejecting OUR credentials', () => {
+  it('answers the refresh grant with 503 and a Retry-After, never "sign in again"', async () => {
+    platformShape = 'invalid_client';
+    const response = await postRefresh(ourRefreshToken());
+
+    expect(response.status).toBe(503);
+    expect(response.headers.get('retry-after')).toBe('30');
+
+    const body = (await response.json()) as { error: string; error_description: string };
+    expect(body.error).toBe('temporarily_unavailable');
+    // The whole point: a wrong INSFORGE_CLIENT_SECRET must not send every
+    // connected user to re-authenticate, because they all would, and every new
+    // sign-in would fail the same way until an operator fixed the config.
+    expect(body.error_description).not.toMatch(/sign in again/i);
+  });
+
+  it('answers the sign-in callback with 503 and a Retry-After', async () => {
+    // The path a ROTATION actually hits: nobody holds a refresh token yet, so
+    // everyone is doing a fresh sign-in and arrives here instead.
+    platformShape = 'invalid_client';
+    const response = await callbackWithJunkCode();
+
+    expect(response.status).toBe(503);
+    expect(response.headers.get('retry-after')).toBe('30');
+    const page = await response.text();
+    expect(page).toMatch(/not with your account/i);
+    expect(page).not.toMatch(/sign in again/i);
+  });
+});
+
+describe('the platform declining the GRANT is still the user', () => {
+  it('keeps the refresh grant on 400 invalid_grant', async () => {
+    platformShape = 'invalid_grant';
+    const response = await postRefresh(ourRefreshToken());
+
+    expect(response.status).toBe(400);
+    const body = (await response.json()) as { error: string; error_description: string };
+    expect(body.error).toBe('invalid_grant');
+    expect(body.error_description).toMatch(/sign in again/i);
+  });
+
+  it('keeps the callback on 400, distinguishable from the credential case', async () => {
+    // The pair is what makes the container-side pre-flight readable: same
+    // request, two platform answers, two statuses. If these ever collapse to
+    // one status there is no unauthenticated way to tell a fumbled rotation
+    // from a bad code on the box that matters.
+    platformShape = 'invalid_grant';
+    const response = await callbackWithJunkCode();
+
+    expect(response.status).toBe(400);
+    expect(response.status).not.toBe(503);
+  });
+});

--- a/src/http/insforge-api.ts
+++ b/src/http/insforge-api.ts
@@ -354,6 +354,47 @@ export async function exchangePlatformCode(params: {
 }
 
 /**
+ * Trade the platform refresh token for a fresh platform access token.
+ *
+ * Same endpoint, same client credentials, same two-outcome contract as the code
+ * exchange above: a thrown InsforgeApiError means we could not get an answer, a
+ * returned body carrying `error` means the platform answered and declined. The
+ * caller needs those apart, because one is retryable and the other means the
+ * user has to sign in again.
+ *
+ * The platform does NOT rotate on use — its refresh path generates a new access
+ * token and keeps the same refresh token — so there is nothing to write back
+ * and no rotation race between two concurrent refreshes of one session. If that
+ * ever changes, the response's `refresh_token` becomes load-bearing and this
+ * comment is where to start.
+ */
+export async function refreshPlatformToken(params: {
+  refreshToken: string;
+  clientId: string;
+  clientSecret: string;
+}): Promise<PlatformTokens> {
+  const response = await platformFetch(`${OAUTH_API_BASE}/token`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      grant_type: 'refresh_token',
+      refresh_token: params.refreshToken,
+      client_id: params.clientId,
+      client_secret: params.clientSecret,
+    }),
+  });
+
+  try {
+    return (await response.json()) as PlatformTokens;
+  } catch {
+    throw new InsforgeApiError(
+      `Token refresh returned an unreadable response (HTTP ${response.status})`,
+      response.status
+    );
+  }
+}
+
+/**
  * Build the access host URL for a project
  * Format: https://{appkey}.{region}.insforge.app
  */

--- a/src/http/oauth-manager.ts
+++ b/src/http/oauth-manager.ts
@@ -1,9 +1,10 @@
 import { createHash, randomBytes } from 'crypto';
 import { sealAuthState, openAuthState, InvalidAuthStateError } from './auth-state.js';
 import { issueAccessToken, readAccessToken } from './access-token.js';
+import { issueRefreshToken } from './refresh-token.js';
 import { getProjectKeyCache } from './project-key-cache.js';
 import { newStateHandle } from './auth-state-cookie.js';
-import { authStateKey, authCodeKey, accessTokenKey } from './config.js';
+import { authStateKey, authCodeKey, accessTokenKey, refreshTokenKey } from './config.js';
 import { isAuthorizationRefusal } from './error-status.js';
 import {
   validateToken,
@@ -242,6 +243,26 @@ export class OAuthManager {
       accessTokenKey()
     );
 
+    // Ours, sealed here rather than at the token endpoint, so the code carries
+    // two tokens of OURS instead of one of ours beside a raw platform
+    // credential. The values it needs — user and project — are in scope at this
+    // point and nowhere later, so building it anywhere else would mean
+    // forwarding them for no reason.
+    //
+    // Undefined when the platform sent no refresh token: an older platform, or
+    // a grant that does not issue one. That is a client without renewal, which
+    // is exactly today's behaviour, rather than an error.
+    const refreshToken = authState.platformRefreshToken
+      ? issueRefreshToken(
+          {
+            userId: user.id,
+            platformRefreshToken: authState.platformRefreshToken,
+            projectId: projectAccess.projectId,
+          },
+          refreshTokenKey()
+        )
+      : undefined;
+
     // No binding row: the access token IS the record. See access-token.ts for
     // why the platform token goes in and the project API key deliberately does
     // not.
@@ -272,11 +293,7 @@ export class OAuthManager {
     const code = sealAuthState(
       {
         accessToken,
-        // Taken from the state rather than added as a parameter: it arrived at
-        // the callback, and threading it through the signature would let a
-        // caller supply an access token and a refresh token that belong to
-        // different sign-ins.
-        refreshToken: authState.platformRefreshToken,
+        refreshToken,
         redirectUri: authState.redirectUri,
         codeChallenge: authState.codeChallenge,
         codeChallengeMethod: authState.codeChallengeMethod,

--- a/src/http/oauth-manager.ts
+++ b/src/http/oauth-manager.ts
@@ -83,6 +83,18 @@ interface AuthorizationState {
    */
   platformAccessToken?: string;
 
+  /**
+   * The platform REFRESH token, from the same exchange.
+   *
+   * Read into a response type and dropped, until now — which is why every
+   * connected client dies after an hour: the token beside this one is a
+   * one-hour JWT and nothing existed to renew it. Safe here for the same reason
+   * as its neighbour, and it needs that reason more: this envelope is
+   * encrypted, and this is the longer-lived of the two credentials by thirty
+   * days to one hour.
+   */
+  platformRefreshToken?: string;
+
   createdAt: number;
 }
 
@@ -117,8 +129,15 @@ export class OAuthManager {
    * 10-minute TTL from the moment the callback wrote it, and the person still
    * has a project to choose.
    */
-  attachPlatformToken(authState: AuthorizationState, platformAccessToken: string): string {
-    return sealAuthState({ ...authState, platformAccessToken }, authStateKey());
+  attachPlatformToken(
+    authState: AuthorizationState,
+    platformAccessToken: string,
+    platformRefreshToken?: string
+  ): string {
+    return sealAuthState(
+      { ...authState, platformAccessToken, platformRefreshToken },
+      authStateKey()
+    );
   }
 
   /**
@@ -253,6 +272,11 @@ export class OAuthManager {
     const code = sealAuthState(
       {
         accessToken,
+        // Taken from the state rather than added as a parameter: it arrived at
+        // the callback, and threading it through the signature would let a
+        // caller supply an access token and a refresh token that belong to
+        // different sign-ins.
+        refreshToken: authState.platformRefreshToken,
         redirectUri: authState.redirectUri,
         codeChallenge: authState.codeChallenge,
         codeChallengeMethod: authState.codeChallengeMethod,
@@ -284,11 +308,12 @@ export class OAuthManager {
     code: string,
     redirectUri: string,
     codeVerifier?: string
-  ): Promise<{ accessToken: string }> {
+  ): Promise<{ accessToken: string; refreshToken?: string }> {
     // No GETDEL, because there is nothing stored. Replay is bounded by PKCE
     // (required at issue time) and by the five-minute expiry sealed inside.
     let payload: {
       accessToken: string;
+      refreshToken?: string;
       redirectUri: string;
       codeChallenge?: string;
       codeChallengeMethod?: string;
@@ -299,7 +324,7 @@ export class OAuthManager {
       throw new Error('Invalid or expired authorization code');
     }
 
-    const { accessToken, redirectUri: storedRedirectUri, codeChallenge, codeChallengeMethod } = payload;
+    const { accessToken, refreshToken, redirectUri: storedRedirectUri, codeChallenge, codeChallengeMethod } = payload;
 
     // Validate redirect URI
     if (redirectUri !== storedRedirectUri) {
@@ -332,7 +357,7 @@ export class OAuthManager {
       }
     }
 
-    return { accessToken };
+    return { accessToken, refreshToken };
   }
   /**
    * Everything a tool call needs, from the token alone plus one cached lookup.

--- a/src/http/refresh-token-capture.test.ts
+++ b/src/http/refresh-token-capture.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+
+/**
+ * The platform's refresh token has to survive three sealed hops to be of any
+ * use, and every one of them is a separate envelope:
+ *
+ *   callback  -> the auth STATE      (attachPlatformToken)
+ *   picker    -> the auth CODE       (createAuthorizationCode)
+ *   exchange  -> back out to us      (exchangeCode)
+ *
+ * Losing it at any hop looks identical from the outside — the sign-in still
+ * works, and the client still dies an hour later. That is precisely the failure
+ * this feature exists to remove, so it is worth pinning per hop rather than
+ * trusting one end-to-end run that nobody can perform without a real account.
+ */
+
+process.env.INSFORGE_CLIENT_SECRET ||= 'test-secret-for-refresh-capture';
+
+let manager: import('./oauth-manager.js').OAuthManager;
+let openAuthState: typeof import('./auth-state.js').openAuthState;
+let sealAuthState: typeof import('./auth-state.js').sealAuthState;
+let authStateKey: typeof import('./config.js').authStateKey;
+let authCodeKey: typeof import('./config.js').authCodeKey;
+
+beforeAll(async () => {
+  const oauth = await import('./oauth-manager.js');
+  const state = await import('./auth-state.js');
+  const config = await import('./config.js');
+  manager = oauth.getOAuthManager();
+  openAuthState = state.openAuthState;
+  sealAuthState = state.sealAuthState;
+  authStateKey = config.authStateKey;
+  authCodeKey = config.authCodeKey;
+});
+
+const PLATFORM_REFRESH = 'platform-refresh-token-value';
+
+async function freshState() {
+  const { sealedState, handle } = await manager.createAuthorizationState({
+    redirectUri: 'http://127.0.0.1:8765/callback',
+    scope: 'mcp:read',
+    codeChallenge: 'a'.repeat(43),
+    codeChallengeMethod: 'S256',
+  });
+  const authState = await manager.getAuthorizationState(sealedState, handle);
+  if (!authState) throw new Error('state did not open');
+  return authState;
+}
+
+describe('hop 1: the callback attaches it to the auth state', () => {
+  it('seals the refresh token alongside the access token', async () => {
+    const sealed = manager.attachPlatformToken(await freshState(), 'access-abc', PLATFORM_REFRESH);
+    const opened = openAuthState<{ platformAccessToken?: string; platformRefreshToken?: string }>(
+      sealed,
+      authStateKey()
+    );
+    expect(opened.platformAccessToken).toBe('access-abc');
+    expect(opened.platformRefreshToken).toBe(PLATFORM_REFRESH);
+  });
+
+  it('does not publish it — the state travels in a cookie', async () => {
+    const sealed = manager.attachPlatformToken(await freshState(), 'access-abc', PLATFORM_REFRESH);
+    expect(sealed).not.toContain(PLATFORM_REFRESH);
+  });
+
+  it('stays undefined when the platform sent none', async () => {
+    // Older platform builds, or a grant that does not issue one. Absence has to
+    // stay absence rather than becoming the string "undefined" in the envelope.
+    const sealed = manager.attachPlatformToken(await freshState(), 'access-abc');
+    const opened = openAuthState<{ platformRefreshToken?: string }>(sealed, authStateKey());
+    expect(opened.platformRefreshToken).toBeUndefined();
+  });
+});
+
+describe('hop 3: the exchange hands it back', () => {
+  // Hop 2 (createAuthorizationCode) calls the live platform to validate the
+  // token, so it is driven here from the code it produces rather than mocked:
+  // seal the same payload shape it seals, and assert the exchange returns the
+  // field. If hop 2 ever stops sealing it, hop 3's contract still holds and
+  // this test still passes — which is why hop 1 above is asserted separately.
+  const redirectUri = 'http://127.0.0.1:8765/callback';
+  const verifier = 'v'.repeat(64);
+
+  async function codeCarrying(refreshToken?: string) {
+    const { createHash } = await import('crypto');
+    return sealAuthState(
+      {
+        accessToken: 'platform-access-token',
+        refreshToken,
+        redirectUri,
+        codeChallenge: createHash('sha256').update(verifier).digest('base64url'),
+        codeChallengeMethod: 'S256',
+      },
+      authCodeKey(),
+      Date.now(),
+      5 * 60
+    );
+  }
+
+  it('returns the refresh token sealed into the code', async () => {
+    const result = await manager.exchangeCode(await codeCarrying(PLATFORM_REFRESH), redirectUri, verifier);
+    expect(result.accessToken).toBe('platform-access-token');
+    expect(result.refreshToken).toBe(PLATFORM_REFRESH);
+  });
+
+  it('returns undefined rather than throwing when the code carries none', async () => {
+    // Every code issued before this change is in exactly this shape, and they
+    // are valid for five more minutes at deploy time. They must still redeem.
+    const result = await manager.exchangeCode(await codeCarrying(undefined), redirectUri, verifier);
+    expect(result.accessToken).toBe('platform-access-token');
+    expect(result.refreshToken).toBeUndefined();
+  });
+});

--- a/src/http/refresh-token.test.ts
+++ b/src/http/refresh-token.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from 'vitest';
+import {
+  issueRefreshToken,
+  readRefreshToken,
+  REFRESH_TOKEN_TTL_SECONDS,
+  MAX_REFRESH_TOKEN_LENGTH,
+} from './refresh-token.js';
+import { deriveRefreshTokenKey, deriveAccessTokenKey, deriveAuthStateKey } from './config.js';
+
+const SECRET = 'a-platform-client-secret';
+const KEY = deriveRefreshTokenKey(SECRET);
+
+const PAYLOAD = {
+  userId: 'user_123',
+  platformRefreshToken: 'platform-refresh-abcdef',
+  projectId: 'proj_456',
+};
+
+describe('the refresh token round trip', () => {
+  it('carries the platform refresh token back out', () => {
+    const token = issueRefreshToken(PAYLOAD, KEY);
+    expect(readRefreshToken(token, KEY)).toEqual(PAYLOAD);
+  });
+
+  it('does not publish the platform credential to anyone holding it', () => {
+    // Encrypted, not signed — the whole reason this envelope is not a JWT. A
+    // readable refresh token would hand a month-long platform credential to
+    // anything that logged the header it travels in.
+    const token = issueRefreshToken(PAYLOAD, KEY);
+    expect(token).not.toContain(PAYLOAD.platformRefreshToken);
+    expect(Buffer.from(token, 'base64url').toString('utf8')).not.toContain(
+      PAYLOAD.platformRefreshToken
+    );
+  });
+});
+
+describe('what must NOT open one', () => {
+  it('refuses a token sealed under a different secret', () => {
+    // The rotation case: INSFORGE_CLIENT_SECRET changes, every refresh token
+    // issued under the old one stops opening. That is the intended revocation
+    // and it is now five artifacts wide, not four.
+    const token = issueRefreshToken(PAYLOAD, KEY);
+    expect(readRefreshToken(token, deriveRefreshTokenKey('a-different-secret'))).toBeNull();
+  });
+
+  it.each([
+    ['the access token key', deriveAccessTokenKey],
+    ['the auth state key', deriveAuthStateKey],
+  ])('refuses a token opened with %s from the SAME secret', (_label, derive) => {
+    // The labels are the whole point of deriving five keys instead of using
+    // one. Same secret, different label, no relationship — so an envelope
+    // cannot be opened by the wrong consumer even inside one deployment.
+    const token = issueRefreshToken(PAYLOAD, KEY);
+    expect(readRefreshToken(token, derive(SECRET) as Buffer)).toBeNull();
+  });
+
+  it('refuses one that has expired', () => {
+    const issuedAt = 1_700_000_000_000;
+    const token = issueRefreshToken(PAYLOAD, KEY, issuedAt);
+    const oneSecondLate = issuedAt + (REFRESH_TOKEN_TTL_SECONDS + 1) * 1000;
+    expect(readRefreshToken(token, KEY, oneSecondLate)).toBeNull();
+    // And is still good the moment before, so the boundary is the TTL rather
+    // than something shorter that happens to pass.
+    expect(readRefreshToken(token, KEY, issuedAt + (REFRESH_TOKEN_TTL_SECONDS - 1) * 1000)).toEqual(
+      PAYLOAD
+    );
+  });
+
+  it('refuses a string that is not one of ours at all', () => {
+    expect(readRefreshToken('not-a-token', KEY)).toBeNull();
+    expect(readRefreshToken('', KEY)).toBeNull();
+  });
+});
+
+describe('the lifetime is the platform s, not ours', () => {
+  it('is thirty days, matching REFRESH_TOKEN_EXPIRY on the platform', () => {
+    // Not a preference. The platform's oauth service expires refresh tokens at
+    // 30 * 24 * 3600; accepting ours for longer would advertise a life the
+    // credential inside does not have — the same mismatch that had the access
+    // token advertising 24h while dying in one.
+    expect(REFRESH_TOKEN_TTL_SECONDS).toBe(30 * 24 * 3600);
+  });
+});
+
+describe('the size bound', () => {
+  it('issues a realistic token well inside the limit', () => {
+    expect(issueRefreshToken(PAYLOAD, KEY).length).toBeLessThan(MAX_REFRESH_TOKEN_LENGTH);
+  });
+
+  it('refuses to issue one that is over it', () => {
+    // The payload is ours, never the caller's, so this fires on a bug in us
+    // rather than on a big request — which is why it throws instead of
+    // returning an error the caller could act on.
+    expect(() =>
+      issueRefreshToken({ ...PAYLOAD, platformRefreshToken: 'x'.repeat(MAX_REFRESH_TOKEN_LENGTH) }, KEY)
+    ).toThrow(/Refusing to issue a refresh token/);
+  });
+});

--- a/src/http/refresh-token.ts
+++ b/src/http/refresh-token.ts
@@ -1,0 +1,108 @@
+import { sealAuthState, openAuthState, InvalidAuthStateError } from './auth-state.js';
+
+/**
+ * The refresh token we hand an MCP client.
+ *
+ * We have never issued one. `/oauth/token` answers `refresh_token` with
+ * `unsupported_grant_type`, and the platform's own refresh token — which it
+ * returns to us at every code exchange — is read into a response type and
+ * dropped on the floor. The consequence is not subtle: the platform's access
+ * token lives ONE HOUR, our envelope advertises whichever is sooner, so every
+ * connected client dies after an hour and the only way back is a browser.
+ *
+ * For a CLI on the user's own machine that is an annoyance. For a hosted
+ * connector — a client that signed in once, in someone else's browser, and now
+ * runs unattended — it is a broken integration.
+ *
+ * Same envelope as the access token and for the same reason: encrypted rather
+ * than signed, because it carries a platform credential and a readable bearer
+ * would publish it to anyone who saw it. Its own key, its own label, no
+ * computable relationship to the other four.
+ */
+export interface RefreshTokenPayload {
+  /** Who this is, from the platform at login. Carried so a refresh can mint an
+   *  access token payload without a second round trip. */
+  userId: string;
+
+  /**
+   * The PLATFORM's refresh token — the thing we currently throw away.
+   *
+   * Not the access token. This is the only field that distinguishes this
+   * envelope from the one next door, and mixing them up would mean handing a
+   * month-long credential to code that expects an hour-long one.
+   */
+  platformRefreshToken: string;
+
+  /** The project chosen at sign-in, so a refreshed access token lands the user
+   *  where they were rather than back at the picker. */
+  projectId: string;
+}
+
+/**
+ * How long we will accept a refresh token.
+ *
+ * Thirty days, and that number is the platform's rather than a preference:
+ * `REFRESH_TOKEN_EXPIRY` in the platform's oauth service is `30 * 24 * 3600`,
+ * so accepting ours for longer would advertise a life the credential inside
+ * does not have — the exact mismatch that made the access token advertise 24h
+ * while dying in one.
+ *
+ * The platform does NOT rotate on use ("keep same refresh token" in its refresh
+ * path), so one issued token stays good for its whole window and we do not have
+ * to reason about a rotation race across concurrent refreshes.
+ */
+export const REFRESH_TOKEN_TTL_SECONDS = 30 * 24 * 60 * 60;
+
+/**
+ * A bound on what we will issue, for the same reason as the access token's —
+ * with one difference worth stating, since it is why this number is not the
+ * same one.
+ *
+ * A refresh token travels in a POST body, never in a header or a URL, so the
+ * 8KB request line and the 16KB header limit that constrain the access token do
+ * not apply here. What still applies is that an unbounded envelope means an
+ * unbounded thing we hand out, and the payload is ours rather than the
+ * caller's, so exceeding this is a bug in us and not a big request.
+ */
+export const MAX_REFRESH_TOKEN_LENGTH = 8192;
+
+export function issueRefreshToken(
+  payload: RefreshTokenPayload,
+  key: Buffer,
+  nowMs: number = Date.now()
+): string {
+  const token = sealAuthState(payload, key, nowMs, REFRESH_TOKEN_TTL_SECONDS);
+
+  if (token.length > MAX_REFRESH_TOKEN_LENGTH) {
+    // No token and no payload in the message: this envelope is worth more than
+    // the access token's, and a length is enough to act on.
+    throw new Error(
+      `Refusing to issue a refresh token of ${token.length} characters ` +
+        `(limit ${MAX_REFRESH_TOKEN_LENGTH}). Something has been added to the sealed payload ` +
+        'that is not bounded.'
+    );
+  }
+
+  return token;
+}
+
+/**
+ * Recover the payload, or null.
+ *
+ * Null rather than a throw, matching `readAccessToken`: every caller turns "not
+ * our token" into `invalid_grant`, an expired refresh is the ordinary case
+ * rather than an attack, and a caller able to tell expired from forged would be
+ * an oracle.
+ */
+export function readRefreshToken(
+  token: string,
+  key: Buffer,
+  nowMs: number = Date.now()
+): RefreshTokenPayload | null {
+  try {
+    return openAuthState<RefreshTokenPayload>(token, key, nowMs);
+  } catch (error) {
+    if (error instanceof InvalidAuthStateError) return null;
+    throw error;
+  }
+}

--- a/src/http/server.ts
+++ b/src/http/server.ts
@@ -1,6 +1,7 @@
 import 'dotenv/config';
 import express, { Request, Response, NextFunction } from 'express';
 import { randomUUID, createHash } from 'crypto';
+import { pathToFileURL } from 'node:url';
 import v8 from 'node:v8';
 
 // Transport imports
@@ -57,7 +58,7 @@ import { PACKAGE_VERSION } from '../shared/version.js';
 // Express App Setup
 // ============================================================================
 
-const app = express();
+export const app = express();
 
 // Trust proxy headers (X-Forwarded-Proto, X-Forwarded-For, etc.)
 // Required for correct protocol detection behind reverse proxies (nginx, AWS ALB, etc.)
@@ -2012,4 +2013,24 @@ async function startServer() {
   }
 }
 
-startServer();
+/**
+ * Start only when this module IS the process entry point.
+ *
+ * Without the guard, importing this file to reach `app` binds the configured
+ * port as a side effect, which is why the route branches had no tests: there was
+ * no way to drive a handler without standing up a real server on a real port.
+ * Two credential guards shipped untested for exactly that reason, and QA proved
+ * it by disabling each in turn and watching the suite stay green.
+ *
+ * Compared against argv[1] through pathToFileURL so the two are the same KIND of
+ * string — `import.meta.url` is a file: URL and argv[1] is a path, and
+ * comparing them directly is a bug that only shows up on the platform whose
+ * separator differs.
+ */
+const isEntryPoint = process.argv[1]
+  ? import.meta.url === pathToFileURL(process.argv[1]).href
+  : false;
+
+if (isEntryPoint) {
+  startServer();
+}

--- a/src/http/server.ts
+++ b/src/http/server.ts
@@ -45,11 +45,12 @@ import {
   isAcceptableClientState,
   MAX_CLIENT_STATE_LENGTH,
 } from './auth-state-cookie.js';
-import { ACCESS_TOKEN_TTL_SECONDS, accessTokenLifetimeSeconds, readAccessToken } from './access-token.js';
+import { ACCESS_TOKEN_TTL_SECONDS, accessTokenLifetimeSeconds, readAccessToken, issueAccessToken } from './access-token.js';
+import { readRefreshToken } from './refresh-token.js';
 import { getProjectKeyCache } from './project-key-cache.js';
-import { accessTokenKey } from './config.js';
+import { accessTokenKey, refreshTokenKey } from './config.js';
 import { statusForHttpError, isAuthorizationRefusal } from './error-status.js';
-import { revokePlatformToken, exchangePlatformCode, type PlatformTokens } from './insforge-api.js';
+import { revokePlatformToken, exchangePlatformCode, refreshPlatformToken, type PlatformTokens } from './insforge-api.js';
 import { PACKAGE_VERSION } from '../shared/version.js';
 
 // ============================================================================
@@ -987,14 +988,94 @@ app.post(OAUTH_ENDPOINTS.token, async (req: Request, res: Response) => {
       });
     }
   } else if (grant_type === 'refresh_token') {
-    getAnalyticsService().trackOAuthFailure({
-      errorType: 'unsupported_grant_type',
-      errorDescription: 'Refresh tokens are not supported',
-      endpoint: '/oauth/token',
+    // Until now this answered `unsupported_grant_type`, which is why every
+    // connected client died after an hour: the platform token sealed in our
+    // access token is a ONE-HOUR JWT, we advertise whichever expiry is sooner,
+    // and there was no way back except a browser. For a CLI that is an
+    // annoyance; for a hosted connector signed in once in someone else's
+    // browser it is a broken integration.
+    const { refresh_token } = req.body;
+
+    if (!refresh_token) {
+      return res.status(400).json({
+        error: 'invalid_request',
+        error_description: 'Missing required parameter: refresh_token',
+      });
+    }
+
+    // Null covers expired, forged, and sealed under a rotated secret alike —
+    // deliberately one answer, since a caller able to tell them apart would be
+    // an oracle. All of them mean the same thing to a client: sign in again.
+    const payload = readRefreshToken(refresh_token as string, refreshTokenKey());
+    if (!payload) {
+      getAnalyticsService().trackOAuthFailure({
+        errorType: 'invalid_grant',
+        errorDescription: 'Refresh token is expired or not ours',
+        endpoint: '/oauth/token',
+      });
+      return res.status(400).json({
+        error: 'invalid_grant',
+        error_description: 'This refresh token has expired or is not valid. Sign in again.',
+      });
+    }
+
+    let tokens: PlatformTokens;
+    try {
+      tokens = await refreshPlatformToken({
+        refreshToken: payload.platformRefreshToken,
+        clientId: INSFORGE_CONFIG.clientId,
+        clientSecret: INSFORGE_CONFIG.clientSecret,
+      });
+    } catch (error) {
+      // Could not reach the platform, which is not the client's fault and may
+      // work on the next attempt — the one case here that must NOT tell someone
+      // to sign in again.
+      console.error('[OAuth] Could not reach the platform to refresh:', error);
+      res.set('Retry-After', '5');
+      return res.status(503).json({
+        error: 'temporarily_unavailable',
+        error_description: 'The InsForge platform could not be reached. Try again shortly.',
+      });
+    }
+
+    if (tokens.error || !tokens.access_token) {
+      // The platform answered and declined: the grant is gone, revoked, or past
+      // its thirty days. That IS sign in again.
+      getAnalyticsService().trackOAuthFailure({
+        errorType: 'invalid_grant',
+        errorDescription: 'Platform refused the refresh token',
+        endpoint: '/oauth/token',
+      });
+      return res.status(400).json({
+        error: 'invalid_grant',
+        error_description: 'This sign-in can no longer be renewed. Sign in again.',
+      });
+    }
+
+    const accessToken = issueAccessToken(
+      {
+        userId: payload.userId,
+        platformAccessToken: tokens.access_token,
+        projectId: payload.projectId,
+      },
+      accessTokenKey()
+    );
+
+    const refreshed = readAccessToken(accessToken, accessTokenKey());
+    getAnalyticsService().trackOAuthSuccess({
+      clientId: req.body.client_id || 'unknown',
+      scope: 'mcp:read mcp:write',
     });
-    return res.status(400).json({
-      error: 'unsupported_grant_type',
-      error_description: 'Refresh tokens are not supported',
+
+    // The SAME refresh token back, not a new one. The platform keeps its own on
+    // refresh, so ours still names a live grant, and re-sealing would hand the
+    // client a different string for no change in what it authorises.
+    return res.json({
+      access_token: accessToken,
+      token_type: 'Bearer',
+      expires_in: refreshed ? accessTokenLifetimeSeconds(refreshed) : ACCESS_TOKEN_TTL_SECONDS,
+      refresh_token,
+      scope: 'mcp:read mcp:write',
     });
   } else {
     getAnalyticsService().trackOAuthFailure({

--- a/src/http/server.ts
+++ b/src/http/server.ts
@@ -2,6 +2,7 @@ import 'dotenv/config';
 import express, { Request, Response, NextFunction } from 'express';
 import { randomUUID, createHash } from 'crypto';
 import { pathToFileURL } from 'node:url';
+import { realpathSync } from 'node:fs';
 import v8 from 'node:v8';
 
 // Transport imports
@@ -2026,10 +2027,26 @@ async function startServer() {
  * string — `import.meta.url` is a file: URL and argv[1] is a path, and
  * comparing them directly is a bug that only shows up on the platform whose
  * separator differs.
+ *
+ * And through realpathSync, which is the part I got wrong first: package.json
+ * publishes this file as the `insforge-mcp-server` bin, npm installs bins as
+ * SYMLINKS, and Node resolves symlinks for `import.meta.url` but not for
+ * argv[1]. So the naive comparison was false when launched by its own installed
+ * name, and the server silently did not start — no error, no log, nothing to
+ * grep for. The container was safe because its start script names the file
+ * directly, which is exactly why testing only that form proved nothing about
+ * the published binary.
  */
-const isEntryPoint = process.argv[1]
-  ? import.meta.url === pathToFileURL(process.argv[1]).href
-  : false;
+const entryPath = process.argv[1];
+let isEntryPoint = false;
+if (entryPath) {
+  try {
+    isEntryPoint = import.meta.url === pathToFileURL(realpathSync(entryPath)).href;
+  } catch {
+    // argv[1] naming something unresolvable is not a reason to refuse to boot.
+    isEntryPoint = import.meta.url === pathToFileURL(entryPath).href;
+  }
+}
 
 if (isEntryPoint) {
   startServer();

--- a/src/http/server.ts
+++ b/src/http/server.ts
@@ -795,7 +795,14 @@ app.get(OAUTH_ENDPOINTS.callback, async (req: Request, res: Response) => {
     // The token rides inside the state instead of a row keyed by it. The
     // state_id therefore CHANGES here — it is the record, so a record with one
     // more field is a different string.
-    const stateWithToken = oauthManager.attachPlatformToken(authState, tokens.access_token);
+    // The refresh token rides along from here. It arrived in this same response
+    // and was dropped on the floor until now, which is the whole reason a
+    // connected client died after an hour.
+    const stateWithToken = oauthManager.attachPlatformToken(
+      authState,
+      tokens.access_token,
+      tokens.refresh_token
+    );
 
     // Same shape as authorize: the record replaces the cookie, the URL carries
     // only the handle. The handle is unchanged, so the two halves still match.

--- a/src/http/server.ts
+++ b/src/http/server.ts
@@ -403,6 +403,17 @@ app.get(OAUTH_ENDPOINTS.protectedResource, (_req: Request, res: Response) => {
 /**
  * OAuth Dynamic Client Registration (RFC 7591)
  */
+/**
+ * A registration metadata field the client may send as an array, or not at all,
+ * or as something else entirely — it is request body, so it is not typed.
+ * Anything that is not an array of strings is treated as absent, which lands on
+ * the defaults below rather than on a 400: the goal is to refuse values we
+ * cannot honour, not to police shapes the caller never meant to send.
+ */
+function asStringArray(value: unknown): string[] {
+  return Array.isArray(value) ? value.filter((v): v is string => typeof v === 'string') : [];
+}
+
 app.post(OAUTH_ENDPOINTS.register, (req: Request, res: Response) => {
   const {
     client_name,
@@ -414,6 +425,38 @@ app.post(OAUTH_ENDPOINTS.register, (req: Request, res: Response) => {
   } = req.body;
 
   const clientName = typeof client_name === 'string' && client_name ? client_name : 'MCP Client';
+
+  // #104: the response used to echo `grant_types` and `response_types` straight
+  // back, so a client that asked for `password` or a device code was TOLD YES at
+  // registration and refused at the token endpoint. A registration response is
+  // the server asserting what it will honour, and a client is entitled to plan
+  // against it.
+  //
+  // Rejected here rather than narrowed silently, for the reason this file keeps
+  // arriving at: refuse where the caller is listening. A client that asked for a
+  // grant it needs should find out now, from a message naming what it can have,
+  // rather than at the first token request in front of a user.
+  const unsupportedGrants = asStringArray(grant_types).filter(
+    (value) => !(OAUTH_CONFIG.grantTypes as readonly string[]).includes(value)
+  );
+  if (unsupportedGrants.length > 0) {
+    return res.status(400).json({
+      error: 'invalid_client_metadata',
+      error_description:
+        `grant_types contains values this server does not support: ${unsupportedGrants.join(', ')}. ` +
+        `Supported: ${OAUTH_CONFIG.grantTypes.join(', ')}.`,
+    });
+  }
+
+  const unsupportedResponses = asStringArray(response_types).filter((value) => value !== 'code');
+  if (unsupportedResponses.length > 0) {
+    return res.status(400).json({
+      error: 'invalid_client_metadata',
+      error_description:
+        `response_types contains values this server does not support: ${unsupportedResponses.join(', ')}. ` +
+        'Supported: code.',
+    });
+  }
 
   // The registration is carried by the id itself, so nothing is written here.
   // mintClientId validates redirect_uris — count, absoluteness, scheme, and

--- a/src/http/server.ts
+++ b/src/http/server.ts
@@ -1091,9 +1091,42 @@ app.post(OAUTH_ENDPOINTS.token, async (req: Request, res: Response) => {
       });
     }
 
+    // The platform declining OUR credentials is not the user's grant expiring,
+    // and collapsing the two is the same mistake as answering "sign in again"
+    // for an unreachable platform — one step further in.
+    //
+    //   {"error":"invalid_client","message":"Invalid client credentials"}  401
+    //
+    // is what it returns when INSFORGE_CLIENT_SECRET is wrong, which is exactly
+    // what a botched rotation or a half-finished client swap produces. Reported
+    // as invalid_grant it tells EVERY connected user to sign in again, they all
+    // do, and every new sign-in fails the same way — a stampede caused by our
+    // config and blamed on their session. Measured against the real platform
+    // rather than assumed.
+    if (tokens.error === 'invalid_client') {
+      console.error(
+        '[OAuth] The platform rejected OUR client credentials on refresh. ' +
+          'INSFORGE_CLIENT_ID/SECRET are wrong for this deployment — this is not the ' +
+          "user's sign-in expiring."
+      );
+      getAnalyticsService().trackOAuthFailure({
+        errorType: 'server_error',
+        errorDescription: 'Platform rejected our client credentials on refresh',
+        endpoint: '/oauth/token',
+      });
+      // Retryable, and deliberately NOT a re-authentication prompt: nothing the
+      // person does fixes our configuration, and asking them to try is how one
+      // bad PATCH becomes a support queue.
+      res.set('Retry-After', '30');
+      return res.status(503).json({
+        error: 'temporarily_unavailable',
+        error_description: 'This server cannot renew sign-ins right now. Try again shortly.',
+      });
+    }
+
     if (tokens.error || !tokens.access_token) {
-      // The platform answered and declined: the grant is gone, revoked, or past
-      // its thirty days. That IS sign in again.
+      // The platform answered and declined the GRANT: gone, revoked, or past its
+      // thirty days. That one IS sign in again.
       getAnalyticsService().trackOAuthFailure({
         errorType: 'invalid_grant',
         errorDescription: 'Platform refused the refresh token',

--- a/src/http/server.ts
+++ b/src/http/server.ts
@@ -988,7 +988,7 @@ app.post(OAUTH_ENDPOINTS.token, async (req: Request, res: Response) => {
 
     try {
       const oauthManager = getOAuthManager();
-      const { accessToken } = await oauthManager.exchangeCode(
+      const { accessToken, refreshToken } = await oauthManager.exchangeCode(
         code as string,
         redirect_uri as string,
         code_verifier as string | undefined
@@ -1012,10 +1012,20 @@ app.post(OAUTH_ENDPOINTS.token, async (req: Request, res: Response) => {
         ? accessTokenLifetimeSeconds(payload)
         : ACCESS_TOKEN_TTL_SECONDS;
 
+      // refresh_token is spread in rather than always present: a code minted
+      // before this shipped carries none, and `refresh_token: undefined` would
+      // serialise the key away anyway — but stating the conditional makes the
+      // absence deliberate rather than incidental. Quinn caught this being
+      // MINTED AND DROPPED one line above: exchangeCode returned it, the
+      // destructure ignored it, and the response omitted it, so discovery
+      // advertised a grant no client could ever obtain the credential for.
+      // Nothing was type-wrong about discarding a returned field, which is why
+      // only a real login found it.
       res.json({
         access_token: accessToken,
         token_type: 'Bearer',
         expires_in: expiresIn,
+        ...(refreshToken ? { refresh_token: refreshToken } : {}),
         scope: 'mcp:read mcp:write',
       });
     } catch (error) {

--- a/src/http/server.ts
+++ b/src/http/server.ts
@@ -820,6 +820,43 @@ app.get(OAUTH_ENDPOINTS.callback, async (req: Request, res: Response) => {
       );
     }
 
+    // Same distinction as the refresh grant, on the path a ROTATION actually
+    // hits: during one nobody holds a refresh token yet, so everyone is doing a
+    // fresh sign-in and arrives here. `invalid_client` means the platform
+    // rejected OUR credentials — a wrong INSFORGE_CLIENT_SECRET — and telling
+    // the person their sign-in failed sends them round a loop that cannot
+    // terminate, because every retry fails identically until an operator fixes
+    // the config. Max caught this one; I had fixed only the refresh path.
+    if (tokens.error === 'invalid_client' || tokens.error === 'unauthorized_client') {
+      console.error(
+        '[OAuth] The platform rejected OUR client credentials during sign-in. ' +
+          'INSFORGE_CLIENT_ID/SECRET are wrong for this deployment — no user action ' +
+          'can fix this.'
+      );
+      getAnalyticsService().trackOAuthFailure({
+        errorType: 'server_error',
+        errorDescription: 'Platform rejected our client credentials at the callback',
+        endpoint: '/oauth/callback',
+      });
+      res.set('Retry-After', '30');
+      return sendOAuthError(
+        req,
+        res,
+        503,
+        {
+          error: 'temporarily_unavailable',
+          error_description: 'This server cannot complete sign-ins right now.',
+        },
+        {
+          heading: 'Sign-in is temporarily unavailable',
+          message:
+            'This is a problem on our side, not with your account or your editor, and ' +
+            'retrying now will not help. We can see it; try again in a few minutes.',
+          action: undefined,
+        }
+      );
+    }
+
     if (tokens.error || !tokens.access_token) {
       console.error('[OAuth] Token exchange error:', tokens);
       getAnalyticsService().trackOAuthFailure({


### PR DESCRIPTION
## TL;DR

Every connected client dies about an hour after signing in and can only recover through a browser. The platform hands us a 30-day refresh token at every code exchange and we dropped it on the floor. This picks it up.

Not a flip blocker. Auth, so per Tony's 07-29 rule it needs QA sign-off before merge — @qa-bot's login-then-refresh is the outstanding item and waits on a credential that doesn't need a human.

## Why an hour

```
access-token.ts:151          min(ACCESS_TOKEN_TTL_SECONDS, platformRemaining)
platform ACCESS_TOKEN_EXPIRY 3600, a signed JWT — so the exp is readable
refresh_token in this repo   a response field we ignored + a grant we rejected
```

Annoying for a CLI. For a hosted connector — signed in once, in someone else's browser, then unattended — it is a broken integration.

## What the platform decides

Read from its oauth service rather than assumed, and both facts make this smaller than it looks:

- `REFRESH_TOKEN_EXPIRY = 30 * 24 * 3600` → ours accepts for 30 days. Accepting longer would advertise a life the credential inside does not have, which is the exact bug that had our access token claiming 24h while dying in one.
- Its refresh path **keeps the same refresh token** → no rotation, so one token is good for its whole window and there is no rotation race across concurrent refreshes.

## Shape

- `refresh-token.ts` — encrypted envelope, own label `mcp-refresh-token-v1`, fifth derived key. Encrypted rather than signed for the same reason as the access token, and it needs that reason more: this is the longer-lived credential by thirty days to one hour.
- Captured at the callback and carried through all three sealed envelopes. Our refresh token is minted in `createAuthorizationCode` beside the access token, because the user and project it needs are in scope exactly there — so the auth code carries two tokens of **ours** rather than one of ours next to a raw platform credential.
- The grant handler, and `grant_types_supported` now advertises it. Advertising is part of the feature: a client that cannot see `refresh_token` opens a browser every hour regardless of what the endpoint would answer.
- Closes #104 — registration echoed back whatever `grant_types` a client asked for, so a client requesting `password` was told yes and refused at the token endpoint.

## The three outcomes a client must tell apart

This is the part worth review attention.

```
our token will not open   400 invalid_grant     expired / forged / sealed under a
                                                rotated secret — ONE answer on
                                                purpose; distinguishing them is an
                                                oracle
platform unreachable      503 + Retry-After     not the client's fault, may work
                                                next time. Must NOT say "sign in
                                                again"
platform rejects US       503 + Retry-After     a wrong INSFORGE_CLIENT_SECRET, i.e.
                                                a botched rotation. Reported as
                                                invalid_grant it tells every user to
                                                re-auth, they all do, and every new
                                                sign-in fails identically
platform declines grant   400 invalid_grant     the grant is revoked or past 30 days.
                                                That one IS sign in again
```

The same refresh token goes back, not a new one: the platform keeps its own on refresh, so ours still names a live grant and re-sealing would hand the client a different string for no change in what it authorises.

## Verification

Unit + mutation on the sealed layers; the route branches black-boxed against a locally booted build, because this repo has no route harness and building one is a bigger job than the feature:

```
DCR password + device_code     400 invalid_client_metadata, naming both
DCR auth_code + refresh_token  201 — echoed because they are now TRUE
token, no refresh_token        400 invalid_request
token, garbage                 400 invalid_grant
token sealed under a ROTATED secret   400 invalid_grant
token OURS + valid, platform declines 400 invalid_grant
platform UNROUTABLE            503 + Retry-After: 5
platform rejects our creds     503 + Retry-After: 30 + operator log
code minted WITH a refresh token    -> response carries refresh_token
code minted WITHOUT one             -> response omits the key
```

@qa-bot independently confirmed the 503 branch discriminates, and found that the token response was dropping `refresh_token` entirely — minted, sealed, and discarded one line later, so no client could ever obtain one. Fixed and re-proved.

**Known gap, stated rather than implied:** a full login-then-refresh against the real platform has not run. Offline proves the wiring; only a real login proves the product, and a test of mine has twice now passed while the thing did not work.

## Rotation note for the runbook

`INSFORGE_CLIENT_SECRET` now invalidates **five** artifacts, not four. The refresh token is the one that makes a rotation user-visible longest — an access token dies within the hour anyway; a 30-day refresh token dies with the rotation and sends that user back through a browser.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds end-to-end `refresh_token` support so clients can renew sessions without reopening a browser, fixing hourly disconnects. Also hardens OAuth flows and fixes a start-up regression in the published `insforge-mcp-server` binary.

- **New Features**
  - Capture the platform refresh token and seal it across state, code, and token using key label `mcp-refresh-token-v1` derived from `INSFORGE_CLIENT_SECRET`.
  - Add `/oauth/token` `refresh_token` grant with clear outcomes:
    - Invalid/expired/not-ours token → 400 `invalid_grant`.
    - Platform unreachable → 503 `temporarily_unavailable` + `Retry-After`.
    - Platform `invalid_client` (our creds wrong) → 503 + `Retry-After`.
  - Advertise `refresh_token` in `grant_types_supported` and include `refresh_token` in the `authorization_code` response. Return the same refresh token on refresh; issue a new access token.
  - Rotation note: a fifth derived key means rotating `INSFORGE_CLIENT_SECRET` now invalidates five artifacts; refresh tokens will require re-auth after rotation.

- **Bug Fixes**
  - DCR now rejects unsupported `grant_types` and `response_types` instead of echoing them (closes #104).
  - Token response includes `refresh_token` when minted; previously it was dropped.
  - Callback maps platform `invalid_client`/`unauthorized_client` to 503 `temporarily_unavailable` + `Retry-After` to avoid user re-auth loops when our `INSFORGE_CLIENT_SECRET` is wrong.
  - Export `app` and add a robust entry-point guard so routes are testable and the published `insforge-mcp-server` npm bin starts correctly (resolve `process.argv[1]` via `realpathSync`/`pathToFileURL`); importing no longer binds a port.

<sup>Written for commit 14bdc2e9474fff5cc5bd89db87ee6b0f4c3c29f7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/insforge-mcp/pull/107?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

