### PR TITLE
verify-deploy: fail the gate when a previous deployment is still serving

### DIFF
--- a/scripts/verify-deploy.mjs
+++ b/scripts/verify-deploy.mjs
@@ -211,6 +211,81 @@ if (memory && typeof memory.heapUsedPct === 'number') {
   console.log('  ~ heap not checked: /health reported no memory block');
 }
 
+// --- every predecessor has to be retired ----------------------------------
+//
+// Shipping a fix does not take the bug off the internet. Each deployment of
+// this server is its own Fly machine on its own public hostname, and on
+// 2026-08-03 twenty-four predecessors were still answering — most on a build
+// predating the OAuth fixes, thirteen still serving an unauthenticated stack
+// trace that production had already stopped serving. The fixes landed and the
+// vulnerable surface did not shrink (insforge-mcp#111).
+//
+// The platform is supposed to reap them: POST /deployments/{id}/activate is
+// documented as tearing down the previous production deployment. It does not,
+// and nothing noticed for a month — so the deploy gate asserts it from outside.
+//
+// This has to PROBE, and the two cheaper signals are both actively misleading:
+// the control plane reports `stopped` for machines that are serving traffic,
+// and /health reports a version that was bumped independently of the fixes
+// landing, so two machines advertised the fixed version while still leaking.
+// Neither field is load-bearing. "Does the hostname answer" is the only true
+// statement available, and it is the one this makes.
+//
+// Scored as 'target', not 'external', deliberately. These are other hosts, but
+// a surviving predecessor is a property of THIS deploy — the thing it failed
+// to do — not the health of some third party we happen to depend on.
+const flyHost = healthBase.match(/^https?:\/\/(mcp-[a-z0-9]+)-(\d+)\.fly\.dev$/i);
+if (!flyHost) {
+  // Never a silent skip. Saying nothing here reads as "no orphans found",
+  // which is exactly the false green this check exists to remove.
+  console.log(
+    '  ~ predecessors NOT checked: VERIFY_HEALTH_URL is not an mcp-<id>-<n>.fly.dev host.\n' +
+      '    Orphaned deployments keep serving the bugs this deploy just fixed.\n' +
+      '    On Manufact, set VERIFY_HEALTH_URL=https://mcp-<serverId>-<deployNo>.fly.dev'
+  );
+} else {
+  const [, appPrefix, currentDeploy] = flyHost;
+  const predecessors = [];
+  for (let n = Number(currentDeploy) - 1; n >= 1; n--) predecessors.push(n);
+
+  // Bounded concurrency: this is the widest thing the gate does and it runs on
+  // every deploy. Retired hostnames fail at DNS in milliseconds, so only the
+  // survivors — the ones worth waiting for — cost a round trip.
+  const BATCH = 16;
+  const alive = [];
+  for (let i = 0; i < predecessors.length; i += BATCH) {
+    const settled = await Promise.all(
+      predecessors.slice(i, i + BATCH).map(async (n) => {
+        // Same standard the target /health is held to above: a 200 proves
+        // something answered, not that OUR process did. A retired machine
+        // whose hostname is still fronted by a proxy answering 200 would
+        // otherwise block a clean deploy forever, and an orphan that has to
+        // be named to count for is the only one worth failing on — it is the
+        // one still serving /oauth/*.
+        const res = await fetchOrNull(`https://${appPrefix}-${n}.fly.dev/health`, {
+          headers: { accept: 'application/json' },
+        });
+        if (res?.status !== 200) return null;
+        const body = await res
+          .json()
+          .catch(() => undefined);
+        return body?.server === 'insforge-mcp' ? n : null;
+      })
+    );
+    alive.push(...settled.filter((n) => n !== null));
+  }
+  alive.sort((a, b) => a - b);
+
+  check(
+    'every previous deployment has been retired',
+    alive.length === 0,
+    alive.length === 0
+      ? `${predecessors.length} predecessor hostname(s) checked, none answering`
+      : `${alive.length} of ${predecessors.length} still answering /health: ${appPrefix}-{${alive.join(',')}}.fly.dev — ` +
+        `they serve /oauth/* on public hostnames, so every fix in this deploy is still reachable unfixed there`
+  );
+}
+
 // --- the 401 has to tell a client where to look ---------------------------
 const unauth = await fetchOrNull(base + '/mcp', {
   method: 'POST',


### PR DESCRIPTION
**TL;DR** — the deploy gate now fails if a previous deployment is still answering. Run against production today it fails with **24 live predecessors**, which is #111 in one line of output.

## Why

Shipping a fix does not take the bug off the internet. Every deployment of this server is its own Fly machine on its own public hostname. `POST /deployments/{id}/activate` is documented as tearing down the previous production deployment — it does not, and nothing noticed for a month.

As of 2026-08-03: 24 predecessors still answering, 20 on a build predating the OAuth fixes, and **13 still serving the unauthenticated stack trace of #106** that production had already stopped serving. The fixes landed and the vulnerable surface did not shrink. Nothing in the repo could have told us that.

## What it does

Derives every predecessor hostname from the deployment number already present in `VERIFY_HEALTH_URL` (`mcp-<serverId>-<n>.fly.dev`, so `n-1 … 1`) and probes them, failing the gate on any that answers as us.

**It probes rather than queries, because both cheaper signals are actively misleading** — this is the part worth reviewing:

- the control plane reports `status: stopped` for machines that are serving traffic (20 of the 24), and
- `/health` reports a version bumped independently of the fixes landing, so **two machines advertised the fixed version while still leaking**.

There is no safe subset selectable by either field. "Does the hostname answer, as us" is the only true statement available.

## Two judgement calls

**Scored as `target`, not `external`.** These are other hosts, which normally means `external` under this file's doctrine. But a surviving predecessor is a property of *this* deploy — the thing it failed to do — not the health of a third party we depend on. It should gate.

**A bare 200 is not enough, and I had this wrong first.** The file already argues 40 lines above that "a 200 on /health proves something answered, not that WE answered". My first version counted any 200 as alive, which would block a clean deploy forever if a retired hostname were ever fronted by a proxy answering 200. It now requires `server === "insforge-mcp"`, the same standard the target `/health` is held to.

**When `VERIFY_HEALTH_URL` is absent it announces that it did not run.** Silence there reads as "no orphans found", which is the false green this exists to remove.

## Verified against production

```
FAIL  every previous deployment has been retired
      — 24 of 80 still answering /health: mcp-bf35bbc3-{41,43,…,80}.fly.dev
exit 1
```
and the passing direction, pointed at a deployment whose predecessors are genuinely retired:
```
PASS  every previous deployment has been retired
```
Both run against real infrastructure, not mocked. eslint clean.

## Cost, stated rather than hidden

Adds ~20s to the gate for 80 predecessors (32s total run). It grows with deployment count — at ~500 deployments this would be a couple of minutes. Bounded and concurrent (16 at a time), and retired hostnames fail at DNS in milliseconds, so only survivors cost a round trip. If that ever bites, the fix is to reap, which is the point.

## Does not fix

The 24 machines currently live. Reaping them is destructive and prod-adjacent and needs a human go-ahead — tracked in #111. This makes sure it cannot happen again silently.

Refs #111, #106


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fail the deploy gate when any previous deployment still answers on its Fly hostname, so fixes aren’t left exposed on old hosts. Probes predecessor hosts derived from `VERIFY_HEALTH_URL` and only flags alive if `/health` returns `server: insforge-mcp`.

- **New Features**
  - Derives `mcp-<id>-<n>.fly.dev` predecessors from `VERIFY_HEALTH_URL` and probes them concurrently; fails if any answer as us.
  - Uses probing instead of control-plane status or version (both were misleading).
  - Requires `/health` to report `server: insforge-mcp`; a 200 alone doesn’t count.
  - Scored as `target` gate; if `VERIFY_HEALTH_URL` is missing/not Fly, it clearly reports that predecessors weren’t checked. Refs #111.

<sup>Written for commit eef74dba980f2b6db933be632d7beb6b867407cb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/insforge-mcp/pull/112?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Strengthened deployment verification to detect and block releases when previous service instances remain reachable.
  * Added concurrent health checks to improve verification speed across prior deployments.
  * Deployment checks now clearly report when health-check configuration is missing or invalid instead of silently passing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->