### PR TITLE
chore(deps): raise override floors to Vanta-patched versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,15 +60,15 @@
     "zod": "^3.23.8"
   },
   "overrides": {
-    "brace-expansion": "^5.0.6",
-    "fast-uri": "^3.1.2",
+    "brace-expansion": "^5.0.9",
+    "fast-uri": "^3.1.5",
     "glob": "^10.5.0",
-    "ip-address": "^10.1.1",
+    "ip-address": "^10.5.0",
     "minimatch": "^9.0.7",
     "@hono/node-server": "^1.19.13",
     "hono": "^4.12.31",
     "lodash": "^4.18.0",
-    "postcss": "^8.5.10",
+    "postcss": "^8.5.26",
     "qs": "^6.15.2",
     "rollup": "^4.59.0",
     "esbuild": "^0.28.1"


### PR DESCRIPTION
## Summary

Follow-up to #114 for the Vanta findings against this repo. The lockfile already resolves all four flagged packages to patched versions, but the `overrides` floors in package.json still permitted resolutions inside the vulnerable ranges (e.g. `fast-uri ^3.1.2`, while CVE-2026-18446 requires >= 3.1.5). This raises the floors so a future lockfile regeneration can never resolve back into a vulnerable range:

| Package | Floor before | Floor after | Covers |
|---|---|---|---|
| brace-expansion | ^5.0.6 | ^5.0.9 | CVE-2026-13149, CVE-2026-14257, CVE-2026-69152 |
| fast-uri | ^3.1.2 | ^3.1.5 | CVE-2026-13676, CVE-2026-16221, CVE-2026-18446 |
| ip-address | ^10.1.1 | ^10.5.0 | CVE-2026-69192 |
| postcss | ^8.5.10 | ^8.5.26 | CVE-2026-73646 |

Resolved versions in package-lock.json are unchanged (already at these versions since #114), so this is a package.json-only change.

## Verification

- `npm audit`: 0 vulnerabilities
- `npm ci`: succeeds with the updated overrides (no lockfile mismatch)
- `npm run build`: success
- `npm test`: 23 files, 318 tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Raises package.json `overrides` floors for Vanta-flagged dependencies to patched versions to prevent future lockfile regenerations from resolving into vulnerable ranges. Resolved versions and runtime behavior are unchanged.

**Review notes**
- Updated floors: `brace-expansion` ^5.0.9; `fast-uri` ^3.1.5; `ip-address` ^10.5.0; `postcss` ^8.5.26.
- Lockfile unchanged; `npm audit` reports 0 vulnerabilities; `npm ci`, build, and tests pass.

<sup>Written for commit d515b091b55bf408091abd2549d49c3572cc2e7c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/insforge-mcp/pull/117?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated several underlying dependency versions to improve compatibility and maintain application stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->